### PR TITLE
reduce the number of call for non-managed and archived repositories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Goliac v0.18.18
+
+- better team validation mechanic
+- implement a lazy loading for some resources to reduce the number of Github call
+
 ## Goliac v0.18.17
 
 - bugfix: better ruleset type check

--- a/browser/goliac-ui/src/components/DashboardApp.vue
+++ b/browser/goliac-ui/src/components/DashboardApp.vue
@@ -210,7 +210,7 @@
                         value: statistics.lastTimeToApply,
                     },
                     {
-                        key: "Lat Number of Github API Calls",
+                        key: "Last Number of Github API Calls",
                         value: statistics.lastGithubApiCalls,
                     },
                     {

--- a/internal/engine/entity_lazy_loader.go
+++ b/internal/engine/entity_lazy_loader.go
@@ -1,0 +1,55 @@
+package engine
+
+// generic lazy loader entity
+// it will be used for the Reconciliator to load the entity from the local or remote
+type LazyLoaderEntity interface {
+	string | *GithubEnvironment
+}
+
+type MappedEntityLazyLoader[T LazyLoaderEntity] interface {
+	GetEntity() map[string]T
+}
+
+// the local version of the lazy loader
+// is just a wrapper around a map
+type LocalLazyLoader[T LazyLoaderEntity] struct {
+	entity map[string]T
+}
+
+func NewLocalLazyLoader[T LazyLoaderEntity](entity map[string]T) *LocalLazyLoader[T] {
+	return &LocalLazyLoader[T]{entity: entity}
+}
+
+func (l *LocalLazyLoader[T]) GetEntity() map[string]T {
+	return l.entity
+}
+
+// the remote version of the lazy loader
+// contains a deferred function to load the entity
+type RemoteLazyLoader[T LazyLoaderEntity] struct {
+	load   func() map[string]T
+	entity map[string]T
+}
+
+func NewRemoteLazyLoader[T LazyLoaderEntity](load func() map[string]T) *RemoteLazyLoader[T] {
+	return &RemoteLazyLoader[T]{load: load}
+}
+
+func (l *RemoteLazyLoader[T]) GetEntity() map[string]T {
+	if l.entity == nil {
+		l.entity = l.load()
+	}
+	return l.entity
+}
+
+// func (l *RemoveMutableLazyLoader[T]) Remove(key string) {
+// 	delete(l.entity, key)
+// }
+
+// func (l *RemoveMutableLazyLoader[T]) Add(key string, value T) {
+// 	l.entity[key] = value
+// }
+
+// func (l *RemoveMutableLazyLoader[T]) Update(key string, value T) {
+// 	l.entity[key] = value
+// }

--- a/internal/engine/goliac_reconciliator.go
+++ b/internal/engine/goliac_reconciliator.go
@@ -632,7 +632,7 @@ func (r *GoliacReconciliatorImpl) reconciliateRepositories(ctx context.Context, 
 		archived := lRepo.BoolProperties["archived"]
 		if !archived {
 			//
-			// "recursive" rulesets comparison
+			// "nested" rulesets comparison
 			//
 			onRulesetAdded := func(rulename string, lRuleset *GithubRuleSet, rRuleset *GithubRuleSet) {
 				// CREATE repo ruleset
@@ -650,7 +650,7 @@ func (r *GoliacReconciliatorImpl) reconciliateRepositories(ctx context.Context, 
 			CompareEntities(lRepo.Rulesets, rRepo.Rulesets, compareRulesets, onRulesetAdded, onRulesetRemoved, onRulesetChange)
 
 			//
-			// "recursive" branchprotections comparison
+			// "nested" branchprotections comparison
 			//
 			onBranchProtectionAdded := func(rulename string, lBp *GithubBranchProtection, rBp *GithubBranchProtection) {
 				// CREATE repo branchprotection
@@ -669,7 +669,7 @@ func (r *GoliacReconciliatorImpl) reconciliateRepositories(ctx context.Context, 
 
 			if manageGithubVariables {
 				//
-				// "recursive" environments comparison
+				// "nested" environments comparison
 				//
 				onEnvironmentAdded := func(environment string, lEnv *GithubEnvironment, rEnv *GithubEnvironment) {
 					// CREATE repo environment

--- a/internal/engine/goliac_reconciliator.go
+++ b/internal/engine/goliac_reconciliator.go
@@ -390,8 +390,8 @@ type GithubRepoComparable struct {
 	Rulesets            map[string]*GithubRuleSet
 	BranchProtections   map[string]*GithubBranchProtection
 	DefaultBranchName   string
-	ActionVariables     map[string]string
-	Environments        map[string]*GithubEnvironment
+	ActionVariables     MappedEntityLazyLoader[string]
+	Environments        MappedEntityLazyLoader[*GithubEnvironment]
 }
 
 type GithubEnvironment struct {
@@ -621,8 +621,8 @@ func (r *GoliacReconciliatorImpl) reconciliateRepositories(ctx context.Context, 
 			Rulesets:            rulesets,
 			BranchProtections:   branchprotections,
 			DefaultBranchName:   lRepo.Spec.DefaultBranchName,
-			Environments:        environments,
-			ActionVariables:     lRepo.Spec.ActionsVariables,
+			Environments:        NewLocalLazyLoader(environments),
+			ActionVariables:     NewLocalLazyLoader(lRepo.Spec.ActionsVariables),
 		})
 	}
 
@@ -698,7 +698,7 @@ func (r *GoliacReconciliatorImpl) reconciliateRepositories(ctx context.Context, 
 					// DELETE repo environment
 					r.DeleteRepositoryEnvironment(ctx, errorCollector, dryrun, remote, reponame, environment)
 				}
-				CompareEntities(lRepo.Environments, rRepo.Environments, compareEnvironments, onEnvironmentAdded, onEnvironmentRemoved, onEnvironmentChange)
+				CompareEntities(lRepo.Environments.GetEntity(), rRepo.Environments.GetEntity(), compareEnvironments, onEnvironmentAdded, onEnvironmentRemoved, onEnvironmentChange)
 			}
 		}
 
@@ -748,8 +748,10 @@ func (r *GoliacReconciliatorImpl) reconciliateRepositories(ctx context.Context, 
 		}
 
 		if manageGithubVariables {
-			if !utils.DeepEqualUnordered(lRepo.ActionVariables, rRepo.ActionVariables) {
-				return false
+			if !archived {
+				if !utils.DeepEqualUnordered(lRepo.ActionVariables.GetEntity(), rRepo.ActionVariables.GetEntity()) {
+					return false
+				}
 			}
 		}
 
@@ -844,21 +846,24 @@ func (r *GoliacReconciliatorImpl) reconciliateRepositories(ctx context.Context, 
 		}
 
 		if manageGithubVariables {
-			if !utils.DeepEqualUnordered(lRepo.ActionVariables, rRepo.ActionVariables) {
+			archived := lRepo.BoolProperties["archived"]
+			if !archived {
+				if !utils.DeepEqualUnordered(lRepo.ActionVariables.GetEntity(), rRepo.ActionVariables.GetEntity()) {
 
-				// Check for removed or changed keys
-				for name, value := range lRepo.ActionVariables {
-					if rValue, ok := rRepo.ActionVariables[name]; !ok {
-						r.AddRepositoryVariable(ctx, errorCollector, dryrun, remote, reponame, name, value)
-					} else if rValue != value {
-						r.UpdateRepositoryVariable(ctx, errorCollector, dryrun, remote, reponame, name, value)
+					// Check for removed or changed keys
+					for name, value := range lRepo.ActionVariables.GetEntity() {
+						if rValue, ok := rRepo.ActionVariables.GetEntity()[name]; !ok {
+							r.AddRepositoryVariable(ctx, errorCollector, dryrun, remote, reponame, name, value)
+						} else if rValue != value {
+							r.UpdateRepositoryVariable(ctx, errorCollector, dryrun, remote, reponame, name, value)
+						}
 					}
-				}
 
-				// Check for added keys
-				for name := range rRepo.ActionVariables {
-					if _, ok := lRepo.ActionVariables[name]; !ok {
-						r.DeleteRepositoryVariable(ctx, errorCollector, dryrun, remote, reponame, name)
+					// Check for added keys
+					for name := range rRepo.ActionVariables.GetEntity() {
+						if _, ok := lRepo.ActionVariables.GetEntity()[name]; !ok {
+							r.DeleteRepositoryVariable(ctx, errorCollector, dryrun, remote, reponame, name)
+						}
 					}
 				}
 			}

--- a/internal/engine/goliac_reconciliator_test.go
+++ b/internal/engine/goliac_reconciliator_test.go
@@ -142,6 +142,18 @@ func (m *GoliacRemoteMock) EnvironmentSecretsPerRepository(ctx context.Context, 
 	return nil, nil
 }
 
+type MockMappedEntityLazyLoader[T any] struct {
+	entity map[string]T
+}
+
+func (m *MockMappedEntityLazyLoader[T]) GetEntity() map[string]T {
+	return m.entity
+}
+
+func NewMockMappedEntityLazyLoader[T any](entity map[string]T) *MockMappedEntityLazyLoader[T] {
+	return &MockMappedEntityLazyLoader[T]{entity: entity}
+}
+
 type ReconciliatorListenerRecorder struct {
 	UsersCreated map[string]string
 	UsersRemoved map[string]string
@@ -1010,9 +1022,11 @@ func TestReconciliationRepo(t *testing.T) {
 			appids:     make(map[string]int),
 		}
 		remote.repos["teams"] = &GithubRepository{
-			Name:           "teams",
-			ExternalUsers:  map[string]string{},
-			BoolProperties: map[string]bool{},
+			Name:                "teams",
+			ExternalUsers:       map[string]string{},
+			BoolProperties:      map[string]bool{},
+			Environments:        NewMockMappedEntityLazyLoader[*GithubEnvironment](map[string]*GithubEnvironment{}),
+			RepositoryVariables: NewMockMappedEntityLazyLoader[string](map[string]string{}),
 		}
 
 		toArchive := make(map[string]*GithubRepoComparable)
@@ -1059,9 +1073,11 @@ func TestReconciliationRepo(t *testing.T) {
 			appids:     make(map[string]int),
 		}
 		remote.repos["teams"] = &GithubRepository{
-			Name:           "teams",
-			ExternalUsers:  map[string]string{},
-			BoolProperties: map[string]bool{},
+			Name:                "teams",
+			ExternalUsers:       map[string]string{},
+			BoolProperties:      map[string]bool{},
+			Environments:        NewMockMappedEntityLazyLoader[*GithubEnvironment](map[string]*GithubEnvironment{}),
+			RepositoryVariables: NewMockMappedEntityLazyLoader[string](map[string]string{}),
 		}
 		existing := &GithubTeam{
 			Name:    "existing",
@@ -2993,7 +3009,7 @@ func TestReconciliationRepositoryEnvironments(t *testing.T) {
 			Name:           "test-repo",
 			ExternalUsers:  map[string]string{},
 			BoolProperties: map[string]bool{},
-			Environments:   map[string]*GithubEnvironment{},
+			Environments:   NewMockMappedEntityLazyLoader(map[string]*GithubEnvironment{}),
 		}
 		remote.repos["test-repo"] = remoteRepo
 
@@ -3039,14 +3055,14 @@ func TestReconciliationRepositoryEnvironments(t *testing.T) {
 			Name:           "test-repo",
 			ExternalUsers:  map[string]string{},
 			BoolProperties: map[string]bool{},
-			Environments: map[string]*GithubEnvironment{
+			Environments: NewMockMappedEntityLazyLoader(map[string]*GithubEnvironment{
 				"production": {
 					Name: "production",
 					Variables: map[string]string{
 						"DB_URL": "prod-db-url",
 					},
 				},
-			},
+			}),
 		}
 		remote.repos["test-repo"] = remoteRepo
 
@@ -3099,14 +3115,14 @@ func TestReconciliationRepositoryEnvironments(t *testing.T) {
 			Name:           "test-repo",
 			ExternalUsers:  map[string]string{},
 			BoolProperties: map[string]bool{},
-			Environments: map[string]*GithubEnvironment{
+			Environments: NewMockMappedEntityLazyLoader(map[string]*GithubEnvironment{
 				"production": {
 					Name: "production",
 					Variables: map[string]string{
 						"DB_URL": "old-prod-db-url",
 					},
 				},
-			},
+			}),
 		}
 		remote.repos["test-repo"] = remoteRepo
 

--- a/internal/engine/goliac_reconciliator_test.go
+++ b/internal/engine/goliac_reconciliator_test.go
@@ -130,7 +130,7 @@ func (m *GoliacRemoteMock) TeamRepositories(ctx context.Context) map[string]map[
 func (m *GoliacRemoteMock) AppIds(ctx context.Context) map[string]int {
 	return m.appids
 }
-func (m *GoliacRemoteMock) CountAssets(ctx context.Context) (int, error) {
+func (m *GoliacRemoteMock) CountAssets(ctx context.Context, warmup bool) (int, error) {
 	return 3, nil
 }
 func (g *GoliacRemoteMock) SetRemoteObservability(feedback observability.RemoteObservability) {

--- a/internal/engine/remote.go
+++ b/internal/engine/remote.go
@@ -76,8 +76,8 @@ type GithubRepository struct {
 	BranchProtections   map[string]*GithubBranchProtection // [pattern]branch protection
 	DefaultBranchName   string
 	IsFork              bool
-	Environments        map[string]*GithubEnvironment // [name]environment
-	RepositoryVariables map[string]string             // [variableName]variableValue
+	Environments        MappedEntityLazyLoader[*GithubEnvironment] // [name]environment
+	RepositoryVariables MappedEntityLazyLoader[string]             // [variableName]variableValue
 	// RepositorySecrets    map[string]string            // [variableName]variableValue
 }
 
@@ -236,14 +236,14 @@ func (g *GoliacRemoteImpl) CountAssets(ctx context.Context) (int, error) {
 	if len(gResult.Errors) > 0 {
 		return 0, fmt.Errorf("graphql error on CountAssets: %v (%v)", gResult.Errors[0].Message, gResult.Errors[0].Path)
 	}
-	totalCount := 2*gResult.Data.Organization.Repositories.TotalCount + // we multiply by 3 because we have the repositories, the teams per repostiory to fetch
+	totalCount := 2*gResult.Data.Organization.Repositories.TotalCount + // we multiply by 2 because we have the repositories, the teams per repostiory to fetch
 		2*gResult.Data.Organization.Teams.TotalCount + // we multiply by 2 because we have the teams and the members per team to fetch
 		gResult.Data.Organization.MembersWithRole.TotalCount +
 		gResult.Data.Organization.SamlIdentityProvider.ExternalIdentities.TotalCount
 
-	if g.manageGithubVariables {
-		totalCount += 2 * gResult.Data.Organization.Repositories.TotalCount // we multiply by 3 because we have the environments per repository, and the variables per repository to fetch
-	}
+	// if g.manageGithubVariables {
+	// 	totalCount += 2 * gResult.Data.Organization.Repositories.TotalCount // we multiply by 3 because we have the environments per repository, and the variables per repository to fetch
+	// }
 
 	return totalCount, nil
 }
@@ -849,16 +849,20 @@ func (g *GoliacRemoteImpl) loadRepositories(ctx context.Context) (map[string]*Gi
 	}
 
 	if g.manageGithubVariables {
-		varsPerRepo, err := g.loadRepositoriesVariables(ctx, config.Config.GithubConcurrentThreads, repositories)
-		if err != nil {
-			return repositories, repositoriesByRefId, err
-		}
-		for repo, vars := range varsPerRepo {
-			repoVars := make(map[string]string)
-			for k, v := range vars {
-				repoVars[k] = v.Value
-			}
-			repositories[repo].RepositoryVariables = repoVars
+		for reponame, repo := range repositories {
+			repo.RepositoryVariables = NewRemoteLazyLoader[string](func() map[string]string {
+				ctx := context.Background()
+				variables, err := g.loadVariablesPerRepository(ctx, repo)
+				if err != nil {
+					logrus.Errorf("error loading variables for repository %s: %v", reponame, err)
+					return map[string]string{}
+				}
+				variablesMap := make(map[string]string)
+				for name, variable := range variables {
+					variablesMap[name] = variable.Value
+				}
+				return variablesMap
+			})
 		}
 
 		// repoSecretsPerRepo, err := g.loadRepositoriesSecrets(ctx, config.Config.GithubConcurrentThreads, repositories)
@@ -869,27 +873,28 @@ func (g *GoliacRemoteImpl) loadRepositories(ctx context.Context) (map[string]*Gi
 		// 	repositories[repo].RepositorySecrets = envSecrets
 		// }
 
-		envPerRepo, err := g.loadEnvironments(ctx, config.Config.GithubConcurrentThreads, repositories)
-		if err != nil {
-			return repositories, repositoriesByRefId, err
-		}
-		for repo, envs := range envPerRepo {
-			repositories[repo].Environments = envs
-		}
+		for reponame, repo := range repositories {
+			repo.Environments = NewRemoteLazyLoader[*GithubEnvironment](func() map[string]*GithubEnvironment {
+				ctx := context.Background()
 
-		envVarsPerRepo, err := g.loadEnvironmentVariables(ctx, config.Config.GithubConcurrentThreads, repositories)
-		if err != nil {
-			return repositories, repositoriesByRefId, err
-		}
-		for repo, envvars := range envVarsPerRepo {
-			for envname, vars := range envvars {
-				env, ok := repositories[repo].Environments[envname]
-				if ok {
-					for k, v := range vars {
-						env.Variables[k] = v.Value
-					}
+				envs, err := g.loadEnvironmentsPerRepository(ctx, repo)
+				if err != nil {
+					logrus.Errorf("error loading environments for repository %s: %v", reponame, err)
+					return map[string]*GithubEnvironment{}
 				}
-			}
+				envsMap := make(map[string]*GithubEnvironment)
+				for name, env := range envs {
+					envsMap[name] = env
+					envvars, err := g.loadEnvironmentVariablesForEnvironmentRepository(ctx, repo.Name, name)
+					if err != nil {
+						logrus.Errorf("error loading variables for environment %s: %v", name, err)
+						return map[string]*GithubEnvironment{}
+					}
+					env.Variables = envvars
+				}
+
+				return envsMap
+			})
 		}
 
 		// envSecretsPerRepo, err := g.loadEnvironmentSecrets(ctx, config.Config.GithubConcurrentThreads, repositories)
@@ -1209,16 +1214,16 @@ func (g *GoliacRemoteImpl) loadTeamRepos(ctx context.Context, repository *Github
 	return teamsrepo, nil
 }
 
-func (g *GoliacRemoteImpl) loadEnvironments(ctx context.Context, maxGoroutines int64, repositories map[string]*GithubRepository) (map[string]map[string]*GithubEnvironment, error) {
-	var childSpan trace.Span
-	if config.Config.OpenTelemetryEnabled {
-		ctx, childSpan = otel.Tracer("goliac").Start(ctx, "loadEnvironmentsRepositories")
-		defer childSpan.End()
-	}
-	logrus.Debug("loading environmentsRepositories")
+// func (g *GoliacRemoteImpl) loadEnvironments(ctx context.Context, maxGoroutines int64, repositories map[string]*GithubRepository) (map[string]map[string]*GithubEnvironment, error) {
+// 	var childSpan trace.Span
+// 	if config.Config.OpenTelemetryEnabled {
+// 		ctx, childSpan = otel.Tracer("goliac").Start(ctx, "loadEnvironmentsRepositories")
+// 		defer childSpan.End()
+// 	}
+// 	logrus.Debug("loading environmentsRepositories")
 
-	return concurrentCall(ctx, maxGoroutines, repositories, "environments_repos", g.loadEnvironmentsPerRepository, g.feedback)
-}
+// 	return concurrentCall(ctx, maxGoroutines, repositories, "environments_repos", g.loadEnvironmentsPerRepository, g.feedback)
+// }
 
 type EnvironmentsResponse struct {
 	TotalCount   int                        `json:"total_count"`
@@ -1260,16 +1265,16 @@ func (g *GoliacRemoteImpl) loadEnvironmentsPerRepository(ctx context.Context, re
 	return envs, nil
 }
 
-func (g *GoliacRemoteImpl) loadRepositoriesVariables(ctx context.Context, maxGoroutines int64, repositories map[string]*GithubRepository) (map[string]map[string]*GithubVariable, error) {
-	var childSpan trace.Span
-	if config.Config.OpenTelemetryEnabled {
-		ctx, childSpan = otel.Tracer("goliac").Start(ctx, "loadVariablesRepositories")
-		defer childSpan.End()
-	}
-	logrus.Debug("loading variablesRepositories")
+// func (g *GoliacRemoteImpl) loadRepositoriesVariables(ctx context.Context, maxGoroutines int64, repositories map[string]*GithubRepository) (map[string]map[string]*GithubVariable, error) {
+// 	var childSpan trace.Span
+// 	if config.Config.OpenTelemetryEnabled {
+// 		ctx, childSpan = otel.Tracer("goliac").Start(ctx, "loadVariablesRepositories")
+// 		defer childSpan.End()
+// 	}
+// 	logrus.Debug("loading variablesRepositories")
 
-	return concurrentCall(ctx, maxGoroutines, repositories, "action_variables_repos", g.loadVariablesPerRepository, g.feedback)
-}
+// 	return concurrentCall(ctx, maxGoroutines, repositories, "action_variables_repos", g.loadVariablesPerRepository, g.feedback)
+// }
 
 type VariablesResponse struct {
 	TotalCount int               `json:"total_count"`
@@ -1308,51 +1313,83 @@ func (g *GoliacRemoteImpl) loadVariablesPerRepository(ctx context.Context, repos
 	return variables, nil
 }
 
-func (g *GoliacRemoteImpl) loadEnvironmentVariables(ctx context.Context, maxGoroutines int64, repositories map[string]*GithubRepository) (map[string]map[string]map[string]*GithubVariable, error) {
-	var childSpan trace.Span
-	if config.Config.OpenTelemetryEnabled {
-		ctx, childSpan = otel.Tracer("goliac").Start(ctx, "loadEnvironmentVariables")
-		defer childSpan.End()
-	}
-	logrus.Debug("loading environmentVariables")
+// func (g *GoliacRemoteImpl) loadEnvironmentVariables(ctx context.Context, maxGoroutines int64, repositories map[string]*GithubRepository) (map[string]map[string]map[string]*GithubVariable, error) {
+// 	var childSpan trace.Span
+// 	if config.Config.OpenTelemetryEnabled {
+// 		ctx, childSpan = otel.Tracer("goliac").Start(ctx, "loadEnvironmentVariables")
+// 		defer childSpan.End()
+// 	}
+// 	logrus.Debug("loading environmentVariables")
 
-	return concurrentCall(ctx, maxGoroutines, repositories, "environment_variables_repos", g.loadEnvironmentVariablesPerRepository, nil)
-}
+// 	return concurrentCall(ctx, maxGoroutines, repositories, "environment_variables_repos", g.loadEnvironmentVariablesPerRepository, nil)
+// }
 
 type EnvironmentsVariablesResponse struct {
 	TotalCount int               `json:"total_count"`
 	Variables  []*GithubVariable `json:"variables"`
 }
 
-func (g *GoliacRemoteImpl) loadEnvironmentVariablesPerRepository(ctx context.Context, repository *GithubRepository) (map[string]map[string]*GithubVariable, error) {
+// func (g *GoliacRemoteImpl) loadEnvironmentVariablesPerRepository(ctx context.Context, repository *GithubRepository) (map[string]map[string]*GithubVariable, error) {
+// 	// https://docs.github.com/en/enterprise-cloud@latest/rest/actions/variables?apiVersion=2022-11-28#list-environment-variables
+// 	envvars := make(map[string]map[string]*GithubVariable)
+// 	respenvs := EnvironmentsVariablesResponse{}
+
+// 	for _, environment := range repository.Environments {
+// 		envvars[environment.Name] = make(map[string]*GithubVariable)
+// 		page := 1
+// 		for page == 1 || len(respenvs.Variables) == 30 {
+// 			data, err := g.client.CallRestAPI(ctx, "/repos/"+g.configGithubOrg+"/"+repository.Name+"/environments/"+environment.Name+"/variables", fmt.Sprintf("page=%d&per_page=30", page), "GET", nil, nil)
+// 			if err != nil {
+// 				return nil, fmt.Errorf("not able to list environments for repo %s: %v", repository.Name, err)
+// 			}
+
+// 			err = json.Unmarshal(data, &respenvs)
+// 			if err != nil {
+// 				return nil, fmt.Errorf("not able to unmarshall environments for repo %s: %v", repository.Name, err)
+// 			}
+
+// 			for _, e := range respenvs.Variables {
+// 				envvars[environment.Name][e.Name] = e
+// 			}
+
+// 			page++
+
+// 			// sanity check to avoid loops
+// 			if page > FORLOOP_STOP {
+// 				break
+// 			}
+// 		}
+// 	}
+
+// 	return envvars, nil
+// }
+
+func (g *GoliacRemoteImpl) loadEnvironmentVariablesForEnvironmentRepository(ctx context.Context, repositoryName string, environmentName string) (map[string]string, error) {
 	// https://docs.github.com/en/enterprise-cloud@latest/rest/actions/variables?apiVersion=2022-11-28#list-environment-variables
-	envvars := make(map[string]map[string]*GithubVariable)
 	respenvs := EnvironmentsVariablesResponse{}
 
-	for _, environment := range repository.Environments {
-		envvars[environment.Name] = make(map[string]*GithubVariable)
-		page := 1
-		for page == 1 || len(respenvs.Variables) == 30 {
-			data, err := g.client.CallRestAPI(ctx, "/repos/"+g.configGithubOrg+"/"+repository.Name+"/environments/"+environment.Name+"/variables", fmt.Sprintf("page=%d&per_page=30", page), "GET", nil, nil)
-			if err != nil {
-				return nil, fmt.Errorf("not able to list environments for repo %s: %v", repository.Name, err)
-			}
+	envvars := make(map[string]string)
+	page := 1
+	for page == 1 || len(respenvs.Variables) == 30 {
+		data, err := g.client.CallRestAPI(ctx, "/repos/"+g.configGithubOrg+"/"+repositoryName+"/environments/"+environmentName+"/variables", fmt.Sprintf("page=%d&per_page=30", page), "GET", nil, nil)
+		if err != nil {
+			return nil, fmt.Errorf("not able to list environments for repo %s: %v", repositoryName, err)
+		}
 
-			err = json.Unmarshal(data, &respenvs)
-			if err != nil {
-				return nil, fmt.Errorf("not able to unmarshall environments for repo %s: %v", repository.Name, err)
-			}
+		err = json.Unmarshal(data, &respenvs)
+		if err != nil {
+			return nil, fmt.Errorf("not able to unmarshall environments for repo %s: %v", repositoryName, err)
+		}
 
-			for _, e := range respenvs.Variables {
-				envvars[environment.Name][e.Name] = e
-			}
+		for _, e := range respenvs.Variables {
+			envvars[e.Name] = e.Value
+		}
 
-			page++
+		page++
 
-			// sanity check to avoid loops
-			if page > FORLOOP_STOP {
-				break
-			}
+		// sanity check to avoid loops
+		if page > FORLOOP_STOP {
+			break
 		}
 	}
 
@@ -3473,7 +3510,7 @@ func (g *GoliacRemoteImpl) AddRepositoryEnvironment(ctx context.Context, errorCo
 	}
 
 	// Check if environment already exists
-	if _, exists := repo.Environments[environmentName]; exists {
+	if _, exists := repo.Environments.GetEntity()[environmentName]; exists {
 		errorCollector.AddError(fmt.Errorf("environment %s already exists in repository %s", environmentName, repositoryName))
 		return
 	}
@@ -3495,7 +3532,7 @@ func (g *GoliacRemoteImpl) AddRepositoryEnvironment(ctx context.Context, errorCo
 	defer g.actionMutex.Unlock()
 
 	// Update local cache
-	repo.Environments[environmentName] = &GithubEnvironment{
+	repo.Environments.GetEntity()[environmentName] = &GithubEnvironment{
 		Name:      environmentName,
 		Variables: map[string]string{},
 	}
@@ -3511,7 +3548,7 @@ func (g *GoliacRemoteImpl) DeleteRepositoryEnvironment(ctx context.Context, erro
 	}
 
 	// Check if environment exists
-	if _, exists := repo.Environments[environmentName]; !exists {
+	if _, exists := repo.Environments.GetEntity()[environmentName]; !exists {
 		errorCollector.AddError(fmt.Errorf("environment %s not found in repository %s", environmentName, repositoryName))
 		return
 	}
@@ -3533,7 +3570,7 @@ func (g *GoliacRemoteImpl) DeleteRepositoryEnvironment(ctx context.Context, erro
 	defer g.actionMutex.Unlock()
 
 	// Update local cache
-	delete(repo.Environments, environmentName)
+	delete(repo.Environments.GetEntity(), environmentName)
 }
 
 // AddRepositoryVariable adds a new variable to a repository
@@ -3546,7 +3583,7 @@ func (g *GoliacRemoteImpl) AddRepositoryVariable(ctx context.Context, errorColle
 	}
 
 	// Check if variable already exists
-	if _, exists := repo.RepositoryVariables[variableName]; exists {
+	if _, exists := repo.RepositoryVariables.GetEntity()[variableName]; exists {
 		errorCollector.AddError(fmt.Errorf("variable %s already exists in repository %s", variableName, repositoryName))
 		return
 	}
@@ -3573,7 +3610,7 @@ func (g *GoliacRemoteImpl) AddRepositoryVariable(ctx context.Context, errorColle
 	defer g.actionMutex.Unlock()
 
 	// Update local cache
-	repo.RepositoryVariables[variableName] = variableValue
+	repo.RepositoryVariables.GetEntity()[variableName] = variableValue
 }
 
 // UpdateRepositoryVariable updates a variable's value in a repository
@@ -3586,7 +3623,7 @@ func (g *GoliacRemoteImpl) UpdateRepositoryVariable(ctx context.Context, errorCo
 	}
 
 	// Check if variable exists
-	if _, exists := repo.RepositoryVariables[variableName]; !exists {
+	if _, exists := repo.RepositoryVariables.GetEntity()[variableName]; !exists {
 		errorCollector.AddError(fmt.Errorf("variable %s not found in repository %s", variableName, repositoryName))
 		return
 	}
@@ -3613,7 +3650,7 @@ func (g *GoliacRemoteImpl) UpdateRepositoryVariable(ctx context.Context, errorCo
 	defer g.actionMutex.Unlock()
 
 	// Update local cache
-	repo.RepositoryVariables[variableName] = variableValue
+	repo.RepositoryVariables.GetEntity()[variableName] = variableValue
 }
 
 // DeleteRepositoryVariable deletes a variable from a repository
@@ -3626,7 +3663,7 @@ func (g *GoliacRemoteImpl) DeleteRepositoryVariable(ctx context.Context, errorCo
 	}
 
 	// Check if variable exists
-	if _, exists := repo.RepositoryVariables[variableName]; !exists {
+	if _, exists := repo.RepositoryVariables.GetEntity()[variableName]; !exists {
 		errorCollector.AddError(fmt.Errorf("variable %s not found in repository %s", variableName, repositoryName))
 		return
 	}
@@ -3648,7 +3685,7 @@ func (g *GoliacRemoteImpl) DeleteRepositoryVariable(ctx context.Context, errorCo
 	defer g.actionMutex.Unlock()
 
 	// Update local cache
-	delete(repo.RepositoryVariables, variableName)
+	delete(repo.RepositoryVariables.GetEntity(), variableName)
 }
 
 // AddRepositoryEnvironmentVariable adds a new variable to a repository environment
@@ -3661,13 +3698,13 @@ func (g *GoliacRemoteImpl) AddRepositoryEnvironmentVariable(ctx context.Context,
 	}
 
 	// Check if environment exists
-	if _, exists := repo.Environments[environmentName]; !exists {
+	if _, exists := repo.Environments.GetEntity()[environmentName]; !exists {
 		errorCollector.AddError(fmt.Errorf("environment %s not found in repository %s", environmentName, repositoryName))
 		return
 	}
 
 	// Check if variable already exists
-	if _, exists := repo.Environments[environmentName].Variables[variableName]; exists {
+	if _, exists := repo.Environments.GetEntity()[environmentName].Variables[variableName]; exists {
 		errorCollector.AddError(fmt.Errorf("variable %s already exists in environment %s of repository %s", variableName, environmentName, repositoryName))
 		return
 	}
@@ -3694,14 +3731,14 @@ func (g *GoliacRemoteImpl) AddRepositoryEnvironmentVariable(ctx context.Context,
 	defer g.actionMutex.Unlock()
 
 	// Update local cache
-	if repo.Environments[environmentName] == nil {
+	if repo.Environments.GetEntity()[environmentName] == nil {
 		e := &GithubEnvironment{
 			Name:      environmentName,
 			Variables: map[string]string{},
 		}
-		repo.Environments[environmentName] = e
+		repo.Environments.GetEntity()[environmentName] = e
 	}
-	repo.Environments[environmentName].Variables[variableName] = variableValue
+	repo.Environments.GetEntity()[environmentName].Variables[variableName] = variableValue
 }
 
 // UpdateRepositoryEnvironmentVariable updates a variable's value in a repository environment
@@ -3714,13 +3751,13 @@ func (g *GoliacRemoteImpl) UpdateRepositoryEnvironmentVariable(ctx context.Conte
 	}
 
 	// Check if environment exists
-	if _, exists := repo.Environments[environmentName]; !exists {
+	if _, exists := repo.Environments.GetEntity()[environmentName]; !exists {
 		errorCollector.AddError(fmt.Errorf("environment %s not found in repository %s", environmentName, repositoryName))
 		return
 	}
 
 	// Check if variable exists
-	if _, exists := repo.Environments[environmentName].Variables[variableName]; !exists {
+	if _, exists := repo.Environments.GetEntity()[environmentName].Variables[variableName]; !exists {
 		errorCollector.AddError(fmt.Errorf("variable %s not found in environment %s of repository %s", variableName, environmentName, repositoryName))
 		return
 	}
@@ -3747,14 +3784,14 @@ func (g *GoliacRemoteImpl) UpdateRepositoryEnvironmentVariable(ctx context.Conte
 	defer g.actionMutex.Unlock()
 
 	// Update local cache
-	if repo.Environments[environmentName] == nil {
+	if repo.Environments.GetEntity()[environmentName] == nil {
 		e := &GithubEnvironment{
 			Name:      environmentName,
 			Variables: map[string]string{},
 		}
-		repo.Environments[environmentName] = e
+		repo.Environments.GetEntity()[environmentName] = e
 	}
-	repo.Environments[environmentName].Variables[variableName] = variableValue
+	repo.Environments.GetEntity()[environmentName].Variables[variableName] = variableValue
 }
 
 // DeleteRepositoryEnvironmentVariable removes a variable from a repository environment
@@ -3767,13 +3804,13 @@ func (g *GoliacRemoteImpl) DeleteRepositoryEnvironmentVariable(ctx context.Conte
 	}
 
 	// Check if environment exists
-	if _, exists := repo.Environments[environmentName]; !exists {
+	if _, exists := repo.Environments.GetEntity()[environmentName]; !exists {
 		errorCollector.AddError(fmt.Errorf("environment %s not found in repository %s", environmentName, repositoryName))
 		return
 	}
 
 	// Check if variable exists
-	if _, exists := repo.Environments[environmentName].Variables[variableName]; !exists {
+	if _, exists := repo.Environments.GetEntity()[environmentName].Variables[variableName]; !exists {
 		errorCollector.AddError(fmt.Errorf("variable %s not found in environment %s of repository %s", variableName, environmentName, repositoryName))
 		return
 	}
@@ -3795,14 +3832,14 @@ func (g *GoliacRemoteImpl) DeleteRepositoryEnvironmentVariable(ctx context.Conte
 	defer g.actionMutex.Unlock()
 
 	// Update local cache
-	if repo.Environments[environmentName] == nil {
+	if repo.Environments.GetEntity()[environmentName] == nil {
 		e := &GithubEnvironment{
 			Name:      environmentName,
 			Variables: map[string]string{},
 		}
-		repo.Environments[environmentName] = e
+		repo.Environments.GetEntity()[environmentName] = e
 	}
-	delete(repo.Environments[environmentName].Variables, variableName)
+	delete(repo.Environments.GetEntity()[environmentName].Variables, variableName)
 }
 
 func (g *GoliacRemoteImpl) Begin(dryrun bool) {

--- a/internal/engine/remote_actions_test.go
+++ b/internal/engine/remote_actions_test.go
@@ -453,201 +453,201 @@ func (m *LoadEnvironmentVariablesPerRepositoryMockClient) GetAppSlug() string {
 	return "mock-app"
 }
 
-func TestLoadEnvironmentVariablesPerRepository(t *testing.T) {
-	t.Run("happy path: load environment variables for repository", func(t *testing.T) {
-		// Setup mock client
-		mockClient := &LoadEnvironmentVariablesPerRepositoryMockClient{
-			responseBody: `{
-				"total_count": 2,
-				"variables": [
-					{
-						"name": "VAR1",
-						"value": "value1",
-						"created_at": "2023-01-01T00:00:00Z",
-						"updated_at": "2023-01-01T00:00:00Z"
-					},
-					{
-						"name": "VAR2",
-						"value": "value2",
-						"created_at": "2023-01-01T00:00:00Z",
-						"updated_at": "2023-01-01T00:00:00Z"
-					}
-				]
-			}`,
-		}
+// func TestLoadEnvironmentVariablesPerRepository(t *testing.T) {
+// 	t.Run("happy path: load environment variables for repository", func(t *testing.T) {
+// 		// Setup mock client
+// 		mockClient := &LoadEnvironmentVariablesPerRepositoryMockClient{
+// 			responseBody: `{
+// 				"total_count": 2,
+// 				"variables": [
+// 					{
+// 						"name": "VAR1",
+// 						"value": "value1",
+// 						"created_at": "2023-01-01T00:00:00Z",
+// 						"updated_at": "2023-01-01T00:00:00Z"
+// 					},
+// 					{
+// 						"name": "VAR2",
+// 						"value": "value2",
+// 						"created_at": "2023-01-01T00:00:00Z",
+// 						"updated_at": "2023-01-01T00:00:00Z"
+// 					}
+// 				]
+// 			}`,
+// 		}
 
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true)
-		repo := &GithubRepository{
-			Name: "test-repo",
-			Id:   123,
-			Environments: map[string]*GithubEnvironment{
-				"production": {
-					Name:      "production",
-					Variables: map[string]string{},
-				},
-			},
-		}
+// 		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true)
+// 		repo := &GithubRepository{
+// 			Name: "test-repo",
+// 			Id:   123,
+// 			Environments: NewMockMappedEntityLazyLoader(map[string]*GithubEnvironment{
+// 				"production": {
+// 					Name:      "production",
+// 					Variables: map[string]string{},
+// 				},
+// 			}),
+// 		}
 
-		ctx := context.TODO()
+// 		ctx := context.TODO()
 
-		// Call loadEnvironmentVariablesPerRepository
-		envVars, err := remoteImpl.loadEnvironmentVariablesPerRepository(ctx, repo)
+// 		// Call loadEnvironmentVariablesPerRepository
+// 		envVars, err := remoteImpl.loadEnvironmentVariablesPerRepository(ctx, repo)
 
-		// Verify no errors occurred
-		assert.NoError(t, err)
-		assert.NotNil(t, envVars)
-		assert.Equal(t, 1, len(envVars))
+// 		// Verify no errors occurred
+// 		assert.NoError(t, err)
+// 		assert.NotNil(t, envVars)
+// 		assert.Equal(t, 1, len(envVars))
 
-		// Verify environment variables were loaded correctly
-		prodVars := envVars["production"]
-		assert.NotNil(t, prodVars)
-		assert.Equal(t, 2, len(prodVars))
-		assert.Equal(t, "value1", prodVars["VAR1"].Value)
-		assert.Equal(t, "value2", prodVars["VAR2"].Value)
+// 		// Verify environment variables were loaded correctly
+// 		prodVars := envVars["production"]
+// 		assert.NotNil(t, prodVars)
+// 		assert.Equal(t, 2, len(prodVars))
+// 		assert.Equal(t, "value1", prodVars["VAR1"].Value)
+// 		assert.Equal(t, "value2", prodVars["VAR2"].Value)
 
-		// Verify API calls were made correctly
-		assert.Equal(t, "/repos/myorg/test-repo/environments/production/variables", mockClient.lastEndpoint)
-		assert.Equal(t, "GET", mockClient.lastMethod)
-	})
+// 		// Verify API calls were made correctly
+// 		assert.Equal(t, "/repos/myorg/test-repo/environments/production/variables", mockClient.lastEndpoint)
+// 		assert.Equal(t, "GET", mockClient.lastMethod)
+// 	})
 
-	t.Run("error path: API error", func(t *testing.T) {
-		mockClient := &LoadEnvironmentVariablesPerRepositoryMockClient{
-			shouldError:  true,
-			errorMessage: "API error",
-		}
+// 	t.Run("error path: API error", func(t *testing.T) {
+// 		mockClient := &LoadEnvironmentVariablesPerRepositoryMockClient{
+// 			shouldError:  true,
+// 			errorMessage: "API error",
+// 		}
 
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true)
-		repo := &GithubRepository{
-			Name: "test-repo",
-			Id:   123,
-			Environments: map[string]*GithubEnvironment{
-				"production": {
-					Name:      "production",
-					Variables: map[string]string{},
-				},
-			},
-		}
+// 		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true)
+// 		repo := &GithubRepository{
+// 			Name: "test-repo",
+// 			Id:   123,
+// 			Environments: NewMockMappedEntityLazyLoader(map[string]*GithubEnvironment{
+// 				"production": {
+// 					Name:      "production",
+// 					Variables: map[string]string{},
+// 				},
+// 			}),
+// 		}
 
-		ctx := context.TODO()
+// 		ctx := context.TODO()
 
-		// Call loadEnvironmentVariablesPerRepository
-		envVars, err := remoteImpl.loadEnvironmentVariablesPerRepository(ctx, repo)
+// 		// Call loadEnvironmentVariablesPerRepository
+// 		envVars, err := remoteImpl.loadEnvironmentVariablesPerRepository(ctx, repo)
 
-		// Verify error was returned
-		assert.Error(t, err)
-		assert.Nil(t, envVars)
-		assert.Contains(t, err.Error(), "API error")
-	})
+// 		// Verify error was returned
+// 		assert.Error(t, err)
+// 		assert.Nil(t, envVars)
+// 		assert.Contains(t, err.Error(), "API error")
+// 	})
 
-	t.Run("happy path: empty environments", func(t *testing.T) {
-		mockClient := &LoadEnvironmentVariablesPerRepositoryMockClient{}
+// 	t.Run("happy path: empty environments", func(t *testing.T) {
+// 		mockClient := &LoadEnvironmentVariablesPerRepositoryMockClient{}
 
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true)
-		repo := &GithubRepository{
-			Name:         "test-repo",
-			Id:           123,
-			Environments: map[string]*GithubEnvironment{},
-		}
+// 		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true)
+// 		repo := &GithubRepository{
+// 			Name:         "test-repo",
+// 			Id:           123,
+// 			Environments: NewMockMappedEntityLazyLoader(map[string]*GithubEnvironment{}),
+// 		}
 
-		ctx := context.TODO()
+// 		ctx := context.TODO()
 
-		// Call loadEnvironmentVariablesPerRepository
-		envVars, err := remoteImpl.loadEnvironmentVariablesPerRepository(ctx, repo)
+// 		// Call loadEnvironmentVariablesPerRepository
+// 		envVars, err := remoteImpl.loadEnvironmentVariablesPerRepository(ctx, repo)
 
-		// Verify no errors and empty map returned
-		assert.NoError(t, err)
-		assert.NotNil(t, envVars)
-		assert.Empty(t, envVars)
-	})
+// 		// Verify no errors and empty map returned
+// 		assert.NoError(t, err)
+// 		assert.NotNil(t, envVars)
+// 		assert.Empty(t, envVars)
+// 	})
 
-	t.Run("error path: GetAccessToken error", func(t *testing.T) {
-		mockClient := &LoadEnvironmentVariablesPerRepositoryMockClient{
-			accessTokenErr: fmt.Errorf("failed to get access token"),
-		}
+// 	t.Run("error path: GetAccessToken error", func(t *testing.T) {
+// 		mockClient := &LoadEnvironmentVariablesPerRepositoryMockClient{
+// 			accessTokenErr: fmt.Errorf("failed to get access token"),
+// 		}
 
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true)
-		repo := &GithubRepository{
-			Name: "test-repo",
-			Id:   123,
-			Environments: map[string]*GithubEnvironment{
-				"production": {
-					Name:      "production",
-					Variables: map[string]string{},
-				},
-			},
-		}
+// 		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true)
+// 		repo := &GithubRepository{
+// 			Name: "test-repo",
+// 			Id:   123,
+// 			Environments: NewMockMappedEntityLazyLoader(map[string]*GithubEnvironment{
+// 				"production": {
+// 					Name:      "production",
+// 					Variables: map[string]string{},
+// 				},
+// 			}),
+// 		}
 
-		ctx := context.TODO()
+// 		ctx := context.TODO()
 
-		// Call loadEnvironmentVariablesPerRepository
-		envVars, err := remoteImpl.loadEnvironmentVariablesPerRepository(ctx, repo)
+// 		// Call loadEnvironmentVariablesPerRepository
+// 		envVars, err := remoteImpl.loadEnvironmentVariablesPerRepository(ctx, repo)
 
-		// Verify error was returned
-		assert.Error(t, err)
-		assert.Nil(t, envVars)
-		assert.Contains(t, err.Error(), "not able to unmarshall environments for repo")
-	})
+// 		// Verify error was returned
+// 		assert.Error(t, err)
+// 		assert.Nil(t, envVars)
+// 		assert.Contains(t, err.Error(), "not able to unmarshall environments for repo")
+// 	})
 
-	t.Run("error path: invalid JSON response", func(t *testing.T) {
-		mockClient := &LoadEnvironmentVariablesPerRepositoryMockClient{
-			responseBody: `invalid json`,
-		}
+// 	t.Run("error path: invalid JSON response", func(t *testing.T) {
+// 		mockClient := &LoadEnvironmentVariablesPerRepositoryMockClient{
+// 			responseBody: `invalid json`,
+// 		}
 
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true)
-		repo := &GithubRepository{
-			Name: "test-repo",
-			Id:   123,
-			Environments: map[string]*GithubEnvironment{
-				"production": {
-					Name:      "production",
-					Variables: map[string]string{},
-				},
-			},
-		}
+// 		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true)
+// 		repo := &GithubRepository{
+// 			Name: "test-repo",
+// 			Id:   123,
+// 			Environments: NewMockMappedEntityLazyLoader(map[string]*GithubEnvironment{
+// 				"production": {
+// 					Name:      "production",
+// 					Variables: map[string]string{},
+// 				},
+// 			}),
+// 		}
 
-		ctx := context.TODO()
+// 		ctx := context.TODO()
 
-		// Call loadEnvironmentVariablesPerRepository
-		envVars, err := remoteImpl.loadEnvironmentVariablesPerRepository(ctx, repo)
+// 		// Call loadEnvironmentVariablesPerRepository
+// 		envVars, err := remoteImpl.loadEnvironmentVariablesPerRepository(ctx, repo)
 
-		// Verify error was returned
-		assert.Error(t, err)
-		assert.Nil(t, envVars)
-		assert.Contains(t, err.Error(), "invalid")
-	})
+// 		// Verify error was returned
+// 		assert.Error(t, err)
+// 		assert.Nil(t, envVars)
+// 		assert.Contains(t, err.Error(), "invalid")
+// 	})
 
-	t.Run("happy path: empty variables list", func(t *testing.T) {
-		mockClient := &LoadEnvironmentVariablesPerRepositoryMockClient{
-			responseBody: `{
-				"total_count": 0,
-				"variables": []
-			}`,
-		}
+// 	t.Run("happy path: empty variables list", func(t *testing.T) {
+// 		mockClient := &LoadEnvironmentVariablesPerRepositoryMockClient{
+// 			responseBody: `{
+// 				"total_count": 0,
+// 				"variables": []
+// 			}`,
+// 		}
 
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true)
-		repo := &GithubRepository{
-			Name: "test-repo",
-			Id:   123,
-			Environments: map[string]*GithubEnvironment{
-				"production": {
-					Name:      "production",
-					Variables: map[string]string{},
-				},
-			},
-		}
+// 		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true)
+// 		repo := &GithubRepository{
+// 			Name: "test-repo",
+// 			Id:   123,
+// 			Environments: NewMockMappedEntityLazyLoader(map[string]*GithubEnvironment{
+// 				"production": {
+// 					Name:      "production",
+// 					Variables: map[string]string{},
+// 				},
+// 			}),
+// 		}
 
-		ctx := context.TODO()
+// 		ctx := context.TODO()
 
-		// Call loadEnvironmentVariablesPerRepository
-		envVars, err := remoteImpl.loadEnvironmentVariablesPerRepository(ctx, repo)
+// 		// Call loadEnvironmentVariablesPerRepository
+// 		envVars, err := remoteImpl.loadEnvironmentVariablesPerRepository(ctx, repo)
 
-		// Verify no errors and empty map returned
-		assert.NoError(t, err)
-		assert.NotNil(t, envVars)
-		assert.Equal(t, 1, len(envVars))
-		assert.Empty(t, envVars["production"])
-	})
-}
+// 		// Verify no errors and empty map returned
+// 		assert.NoError(t, err)
+// 		assert.NotNil(t, envVars)
+// 		assert.Equal(t, 1, len(envVars))
+// 		assert.Empty(t, envVars["production"])
+// 	})
+// }
 
 // LoadRepositoriesVariablesMockClient is a mock client for testing repository variables loading
 type LoadRepositoriesVariablesMockClient struct {
@@ -704,181 +704,181 @@ func (m *LoadRepositoriesVariablesMockClient) GetAppSlug() string {
 	return "mock-app"
 }
 
-func TestLoadRepositoriesVariables(t *testing.T) {
-	t.Run("happy path: load variables for multiple repositories", func(t *testing.T) {
-		// Setup mock client
-		mockClient := &LoadRepositoriesVariablesMockClient{
-			responseBody: `{
-				"total_count": 2,
-				"variables": [
-					{
-						"name": "VAR1",
-						"value": "value1",
-						"created_at": "2023-01-01T00:00:00Z",
-						"updated_at": "2023-01-01T00:00:00Z"
-					},
-					{
-						"name": "VAR2",
-						"value": "value2",
-						"created_at": "2023-01-01T00:00:00Z",
-						"updated_at": "2023-01-01T00:00:00Z"
-					}
-				]
-			}`,
-		}
+// func TestLoadRepositoriesVariables(t *testing.T) {
+// 	t.Run("happy path: load variables for multiple repositories", func(t *testing.T) {
+// 		// Setup mock client
+// 		mockClient := &LoadRepositoriesVariablesMockClient{
+// 			responseBody: `{
+// 				"total_count": 2,
+// 				"variables": [
+// 					{
+// 						"name": "VAR1",
+// 						"value": "value1",
+// 						"created_at": "2023-01-01T00:00:00Z",
+// 						"updated_at": "2023-01-01T00:00:00Z"
+// 					},
+// 					{
+// 						"name": "VAR2",
+// 						"value": "value2",
+// 						"created_at": "2023-01-01T00:00:00Z",
+// 						"updated_at": "2023-01-01T00:00:00Z"
+// 					}
+// 				]
+// 			}`,
+// 		}
 
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true)
-		repositories := map[string]*GithubRepository{
-			"repo1": {
-				Name: "repo1",
-				Id:   123,
-			},
-			"repo2": {
-				Name: "repo2",
-				Id:   456,
-			},
-		}
+// 		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true)
+// 		repositories := map[string]*GithubRepository{
+// 			"repo1": {
+// 				Name: "repo1",
+// 				Id:   123,
+// 			},
+// 			"repo2": {
+// 				Name: "repo2",
+// 				Id:   456,
+// 			},
+// 		}
 
-		ctx := context.TODO()
-		maxGoroutines := int64(2)
+// 		ctx := context.TODO()
+// 		maxGoroutines := int64(2)
 
-		// Call loadRepositoriesVariables
-		varsMap, err := remoteImpl.loadRepositoriesVariables(ctx, maxGoroutines, repositories)
+// 		// Call loadRepositoriesVariables
+// 		varsMap, err := remoteImpl.loadRepositoriesVariables(ctx, maxGoroutines, repositories)
 
-		// Verify no errors occurred
-		assert.NoError(t, err)
-		assert.Equal(t, 3, mockClient.callCount)
+// 		// Verify no errors occurred
+// 		assert.NoError(t, err)
+// 		assert.Equal(t, 3, mockClient.callCount)
 
-		// Verify variables were loaded correctly for each repository
-		assert.Equal(t, 2, len(varsMap)) // Two repositories
+// 		// Verify variables were loaded correctly for each repository
+// 		assert.Equal(t, 2, len(varsMap)) // Two repositories
 
-		// Check repo1 variables
-		repo1Vars := varsMap["repo1"]
-		assert.NotNil(t, repo1Vars)
-		assert.Equal(t, 2, len(repo1Vars))
-		assert.Equal(t, "value1", repo1Vars["VAR1"].Value)
-		assert.Equal(t, "value2", repo1Vars["VAR2"].Value)
+// 		// Check repo1 variables
+// 		repo1Vars := varsMap["repo1"]
+// 		assert.NotNil(t, repo1Vars)
+// 		assert.Equal(t, 2, len(repo1Vars))
+// 		assert.Equal(t, "value1", repo1Vars["VAR1"].Value)
+// 		assert.Equal(t, "value2", repo1Vars["VAR2"].Value)
 
-		// Check repo2 variables
-		repo2Vars := varsMap["repo2"]
-		assert.NotNil(t, repo2Vars)
-		assert.Equal(t, 2, len(repo2Vars))
-		assert.Equal(t, "value1", repo2Vars["VAR1"].Value)
-		assert.Equal(t, "value2", repo2Vars["VAR2"].Value)
+// 		// Check repo2 variables
+// 		repo2Vars := varsMap["repo2"]
+// 		assert.NotNil(t, repo2Vars)
+// 		assert.Equal(t, 2, len(repo2Vars))
+// 		assert.Equal(t, "value1", repo2Vars["VAR1"].Value)
+// 		assert.Equal(t, "value2", repo2Vars["VAR2"].Value)
 
-		// Verify API calls were made with correct endpoints
-		assert.Contains(t, mockClient.lastEndpoint, "/actions/variables")
-	})
+// 		// Verify API calls were made with correct endpoints
+// 		assert.Contains(t, mockClient.lastEndpoint, "/actions/variables")
+// 	})
 
-	t.Run("error path: API error", func(t *testing.T) {
-		// Setup mock client with error
-		mockClient := &LoadRepositoriesVariablesMockClient{
-			shouldError:  true,
-			errorMessage: "API error",
-		}
+// 	t.Run("error path: API error", func(t *testing.T) {
+// 		// Setup mock client with error
+// 		mockClient := &LoadRepositoriesVariablesMockClient{
+// 			shouldError:  true,
+// 			errorMessage: "API error",
+// 		}
 
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true)
-		repositories := map[string]*GithubRepository{
-			"repo1": {
-				Name: "repo1",
-				Id:   123,
-			},
-		}
+// 		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true)
+// 		repositories := map[string]*GithubRepository{
+// 			"repo1": {
+// 				Name: "repo1",
+// 				Id:   123,
+// 			},
+// 		}
 
-		ctx := context.TODO()
-		maxGoroutines := int64(2)
+// 		ctx := context.TODO()
+// 		maxGoroutines := int64(2)
 
-		// Call loadRepositoriesVariables
-		_, err := remoteImpl.loadRepositoriesVariables(ctx, maxGoroutines, repositories)
+// 		// Call loadRepositoriesVariables
+// 		_, err := remoteImpl.loadRepositoriesVariables(ctx, maxGoroutines, repositories)
 
-		// Verify error was returned
-		assert.Error(t, err)
-	})
+// 		// Verify error was returned
+// 		assert.Error(t, err)
+// 	})
 
-	t.Run("happy path: concurrent loading with rate limiting", func(t *testing.T) {
-		// Setup mock client with response for multiple repositories
-		mockClient := &LoadRepositoriesVariablesMockClient{
-			responseBody: `{
-				"total_count": 1,
-				"variables": [
-					{
-						"name": "VAR1",
-						"value": "value1"
-					}
-				]
-			}`,
-		}
+// 	t.Run("happy path: concurrent loading with rate limiting", func(t *testing.T) {
+// 		// Setup mock client with response for multiple repositories
+// 		mockClient := &LoadRepositoriesVariablesMockClient{
+// 			responseBody: `{
+// 				"total_count": 1,
+// 				"variables": [
+// 					{
+// 						"name": "VAR1",
+// 						"value": "value1"
+// 					}
+// 				]
+// 			}`,
+// 		}
 
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true)
-		repositories := map[string]*GithubRepository{}
+// 		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true)
+// 		repositories := map[string]*GithubRepository{}
 
-		// Create 5 test repositories
-		for i := 1; i <= 5; i++ {
-			repoName := fmt.Sprintf("repo%d", i)
-			repositories[repoName] = &GithubRepository{
-				Name: repoName,
-				Id:   i,
-			}
-		}
+// 		// Create 5 test repositories
+// 		for i := 1; i <= 5; i++ {
+// 			repoName := fmt.Sprintf("repo%d", i)
+// 			repositories[repoName] = &GithubRepository{
+// 				Name: repoName,
+// 				Id:   i,
+// 			}
+// 		}
 
-		ctx := context.TODO()
-		maxGoroutines := int64(2) // Limit concurrent operations
+// 		ctx := context.TODO()
+// 		maxGoroutines := int64(2) // Limit concurrent operations
 
-		// Call loadRepositoriesVariables
-		varsMap, err := remoteImpl.loadRepositoriesVariables(ctx, maxGoroutines, repositories)
+// 		// Call loadRepositoriesVariables
+// 		varsMap, err := remoteImpl.loadRepositoriesVariables(ctx, maxGoroutines, repositories)
 
-		// Verify no errors occurred
-		assert.NoError(t, err)
-		assert.Equal(t, 6, mockClient.callCount)
-		assert.Equal(t, 5, len(varsMap))
+// 		// Verify no errors occurred
+// 		assert.NoError(t, err)
+// 		assert.Equal(t, 6, mockClient.callCount)
+// 		assert.Equal(t, 5, len(varsMap))
 
-		// Verify each repository has its variables
-		for _, repoVars := range varsMap {
-			assert.Equal(t, 1, len(repoVars))
-			assert.NotNil(t, repoVars["VAR1"])
-			assert.Equal(t, "value1", repoVars["VAR1"].Value)
-		}
-	})
+// 		// Verify each repository has its variables
+// 		for _, repoVars := range varsMap {
+// 			assert.Equal(t, 1, len(repoVars))
+// 			assert.NotNil(t, repoVars["VAR1"])
+// 			assert.Equal(t, "value1", repoVars["VAR1"].Value)
+// 		}
+// 	})
 
-	t.Run("error path: context cancellation", func(t *testing.T) {
-		mockClient := &LoadRepositoriesVariablesMockClient{}
+// 	t.Run("error path: context cancellation", func(t *testing.T) {
+// 		mockClient := &LoadRepositoriesVariablesMockClient{}
 
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true)
-		repositories := map[string]*GithubRepository{
-			"repo1": {
-				Name: "repo1",
-				Id:   123,
-			},
-		}
+// 		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true)
+// 		repositories := map[string]*GithubRepository{
+// 			"repo1": {
+// 				Name: "repo1",
+// 				Id:   123,
+// 			},
+// 		}
 
-		ctx, cancel := context.WithCancel(context.Background())
-		cancel() // Cancel context immediately
-		maxGoroutines := int64(2)
+// 		ctx, cancel := context.WithCancel(context.Background())
+// 		cancel() // Cancel context immediately
+// 		maxGoroutines := int64(2)
 
-		// Call loadRepositoriesVariables with cancelled context
-		_, err := remoteImpl.loadRepositoriesVariables(ctx, maxGoroutines, repositories)
+// 		// Call loadRepositoriesVariables with cancelled context
+// 		_, err := remoteImpl.loadRepositoriesVariables(ctx, maxGoroutines, repositories)
 
-		// Verify context cancellation error
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "not able to unmarshall action variables for repo")
-	})
+// 		// Verify context cancellation error
+// 		assert.Error(t, err)
+// 		assert.Contains(t, err.Error(), "not able to unmarshall action variables for repo")
+// 	})
 
-	t.Run("happy path: empty repositories map", func(t *testing.T) {
-		mockClient := &LoadRepositoriesVariablesMockClient{}
+// 	t.Run("happy path: empty repositories map", func(t *testing.T) {
+// 		mockClient := &LoadRepositoriesVariablesMockClient{}
 
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true)
-		repositories := map[string]*GithubRepository{}
+// 		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true)
+// 		repositories := map[string]*GithubRepository{}
 
-		ctx := context.TODO()
-		maxGoroutines := int64(2)
+// 		ctx := context.TODO()
+// 		maxGoroutines := int64(2)
 
-		// Call loadRepositoriesVariables
-		varsMap, err := remoteImpl.loadRepositoriesVariables(ctx, maxGoroutines, repositories)
+// 		// Call loadRepositoriesVariables
+// 		varsMap, err := remoteImpl.loadRepositoriesVariables(ctx, maxGoroutines, repositories)
 
-		// Verify no errors and empty map returned
-		assert.NoError(t, err)
-		assert.NotNil(t, varsMap)
-		assert.Empty(t, varsMap)
-		assert.Equal(t, 2, mockClient.callCount)
-	})
-}
+// 		// Verify no errors and empty map returned
+// 		assert.NoError(t, err)
+// 		assert.NotNil(t, varsMap)
+// 		assert.Empty(t, varsMap)
+// 		assert.Equal(t, 2, mockClient.callCount)
+// 	})
+// }

--- a/internal/engine/remote_repository_environment_test.go
+++ b/internal/engine/remote_repository_environment_test.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/goliac-project/goliac/internal/observability"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -65,8 +66,8 @@ func (m *LoadEnvironmentVariablesMockClient) GetAppSlug() string {
 	return "mock-app"
 }
 
-func TestLoadEnvironmentVariables(t *testing.T) {
-	t.Run("happy path: load environment variables for multiple repositories", func(t *testing.T) {
+func TestLoadEnvironmentVariablesForEnvironmentRepository(t *testing.T) {
+	t.Run("happy path: load environment variables for a repository environment", func(t *testing.T) {
 		// Setup mock client
 		mockClient := &LoadEnvironmentVariablesMockClient{
 			responseBody: `{
@@ -89,61 +90,23 @@ func TestLoadEnvironmentVariables(t *testing.T) {
 		}
 
 		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true)
-		repositories := map[string]*GithubRepository{
-			"repo1": {
-				Name: "repo1",
-				Id:   123,
-				Environments: map[string]*GithubEnvironment{
-					"production": {
-						Name:      "production",
-						Variables: map[string]string{},
-					},
-				},
-			},
-			"repo2": {
-				Name: "repo2",
-				Id:   456,
-				Environments: map[string]*GithubEnvironment{
-					"staging": {
-						Name:      "staging",
-						Variables: map[string]string{},
-					},
-				},
-			},
-		}
-
 		ctx := context.TODO()
 
-		// Call loadEnvironmentVariables
-		envVars, err := remoteImpl.loadEnvironmentVariables(ctx, 2, repositories)
+		// Call loadEnvironmentVariablesForEnvironmentRepository
+		envVars, err := remoteImpl.loadEnvironmentVariablesForEnvironmentRepository(ctx, "test-repo", "production")
 
 		// Verify no errors occurred
 		assert.NoError(t, err)
 		assert.NotNil(t, envVars)
 		assert.Equal(t, 2, len(envVars))
+		assert.Equal(t, "value1", envVars["VAR1"])
+		assert.Equal(t, "value2", envVars["VAR2"])
 
-		// Verify environment variables were loaded correctly for repo1
-		repo1Vars := envVars["repo1"]
-		assert.NotNil(t, repo1Vars)
-		assert.Equal(t, 1, len(repo1Vars))
-		prodVars := repo1Vars["production"]
-		assert.NotNil(t, prodVars)
-		assert.Equal(t, 2, len(prodVars))
-		assert.Equal(t, "value1", prodVars["VAR1"].Value)
-		assert.Equal(t, "value2", prodVars["VAR2"].Value)
-
-		// Verify environment variables were loaded correctly for repo2
-		repo2Vars := envVars["repo2"]
-		assert.NotNil(t, repo2Vars)
-		assert.Equal(t, 1, len(repo2Vars))
-		stagingVars := repo2Vars["staging"]
-		assert.NotNil(t, stagingVars)
-		assert.Equal(t, 2, len(stagingVars))
-		assert.Equal(t, "value1", stagingVars["VAR1"].Value)
-		assert.Equal(t, "value2", stagingVars["VAR2"].Value)
-
-		// Verify API calls were made correctly
-		assert.Equal(t, 3, mockClient.callCount) // 2 calls per repository (1 per environment)
+		// Verify API call was made correctly
+		assert.Equal(t, 2, mockClient.callCount)
+		assert.Equal(t, "/repos/myorg/test-repo/environments/production/variables", mockClient.lastEndpoint)
+		assert.Equal(t, "page=1&per_page=30", mockClient.lastParameters)
+		assert.Equal(t, "GET", mockClient.lastMethod)
 	})
 
 	t.Run("error path: API error", func(t *testing.T) {
@@ -153,68 +116,15 @@ func TestLoadEnvironmentVariables(t *testing.T) {
 		}
 
 		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true)
-		repositories := map[string]*GithubRepository{
-			"repo1": {
-				Name: "repo1",
-				Id:   123,
-				Environments: map[string]*GithubEnvironment{
-					"production": {
-						Name:      "production",
-						Variables: map[string]string{},
-					},
-				},
-			},
-		}
-
 		ctx := context.TODO()
 
-		// Call loadEnvironmentVariables
-		_, err := remoteImpl.loadEnvironmentVariables(ctx, 2, repositories)
+		// Call loadEnvironmentVariablesForEnvironmentRepository
+		envVars, err := remoteImpl.loadEnvironmentVariablesForEnvironmentRepository(ctx, "test-repo", "production")
 
 		// Verify error was returned
 		assert.Error(t, err)
+		assert.Nil(t, envVars)
 		assert.Contains(t, err.Error(), "API error")
-	})
-
-	t.Run("happy path: empty repositories", func(t *testing.T) {
-		mockClient := &LoadEnvironmentVariablesMockClient{}
-
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true)
-		repositories := map[string]*GithubRepository{}
-
-		ctx := context.TODO()
-
-		// Call loadEnvironmentVariables
-		envVars, err := remoteImpl.loadEnvironmentVariables(ctx, 2, repositories)
-
-		// Verify no errors and empty map returned
-		assert.NoError(t, err)
-		assert.NotNil(t, envVars)
-		assert.Empty(t, envVars)
-	})
-
-	t.Run("happy path: repositories with no environments", func(t *testing.T) {
-		mockClient := &LoadEnvironmentVariablesMockClient{}
-
-		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true)
-		repositories := map[string]*GithubRepository{
-			"repo1": {
-				Name:         "repo1",
-				Id:           123,
-				Environments: map[string]*GithubEnvironment{},
-			},
-		}
-
-		ctx := context.TODO()
-
-		// Call loadEnvironmentVariables
-		envVars, err := remoteImpl.loadEnvironmentVariables(ctx, 2, repositories)
-
-		// Verify no errors and empty map returned
-		assert.NoError(t, err)
-		assert.NotNil(t, envVars)
-		assert.Equal(t, 1, len(envVars))
-		assert.Empty(t, envVars["repo1"])
 	})
 
 	t.Run("error path: invalid JSON response", func(t *testing.T) {
@@ -223,26 +133,14 @@ func TestLoadEnvironmentVariables(t *testing.T) {
 		}
 
 		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true)
-		repositories := map[string]*GithubRepository{
-			"repo1": {
-				Name: "repo1",
-				Id:   123,
-				Environments: map[string]*GithubEnvironment{
-					"production": {
-						Name:      "production",
-						Variables: map[string]string{},
-					},
-				},
-			},
-		}
-
 		ctx := context.TODO()
 
-		// Call loadEnvironmentVariables
-		_, err := remoteImpl.loadEnvironmentVariables(ctx, 2, repositories)
+		// Call loadEnvironmentVariablesForEnvironmentRepository
+		envVars, err := remoteImpl.loadEnvironmentVariablesForEnvironmentRepository(ctx, "test-repo", "production")
 
 		// Verify error was returned
 		assert.Error(t, err)
+		assert.Nil(t, envVars)
 		assert.Contains(t, err.Error(), "invalid")
 	})
 
@@ -255,36 +153,22 @@ func TestLoadEnvironmentVariables(t *testing.T) {
 		}
 
 		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true)
-		repositories := map[string]*GithubRepository{
-			"repo1": {
-				Name: "repo1",
-				Id:   123,
-				Environments: map[string]*GithubEnvironment{
-					"production": {
-						Name:      "production",
-						Variables: map[string]string{},
-					},
-				},
-			},
-		}
-
 		ctx := context.TODO()
 
-		// Call loadEnvironmentVariables
-		envVars, err := remoteImpl.loadEnvironmentVariables(ctx, 2, repositories)
+		// Call loadEnvironmentVariablesForEnvironmentRepository
+		envVars, err := remoteImpl.loadEnvironmentVariablesForEnvironmentRepository(ctx, "test-repo", "production")
 
 		// Verify no errors and empty map returned
 		assert.NoError(t, err)
 		assert.NotNil(t, envVars)
-		assert.Equal(t, 1, len(envVars))
-		assert.Equal(t, 1, len(envVars["repo1"]))
-		assert.Empty(t, envVars["repo1"]["production"])
+		assert.Empty(t, envVars)
 	})
 
-	t.Run("happy path: concurrent loading with rate limiting", func(t *testing.T) {
+	t.Run("happy path: pagination", func(t *testing.T) {
+		// Setup mock client with pagination responses
 		mockClient := &LoadEnvironmentVariablesMockClient{
 			responseBody: `{
-				"total_count": 1,
+				"total_count": 2,
 				"variables": [
 					{
 						"name": "VAR1",
@@ -297,55 +181,1489 @@ func TestLoadEnvironmentVariables(t *testing.T) {
 		}
 
 		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true)
-		repositories := map[string]*GithubRepository{
-			"repo1": {
-				Name: "repo1",
-				Id:   123,
-				Environments: map[string]*GithubEnvironment{
-					"production": {
-						Name:      "production",
-						Variables: map[string]string{},
-					},
-				},
-			},
-			"repo2": {
-				Name: "repo2",
-				Id:   456,
-				Environments: map[string]*GithubEnvironment{
-					"staging": {
-						Name:      "staging",
-						Variables: map[string]string{},
-					},
-				},
-			},
-			"repo3": {
-				Name: "repo3",
-				Id:   789,
-				Environments: map[string]*GithubEnvironment{
-					"development": {
-						Name:      "development",
-						Variables: map[string]string{},
-					},
-				},
-			},
-		}
-
 		ctx := context.TODO()
 
-		// Call loadEnvironmentVariables with maxGoroutines = 2
-		envVars, err := remoteImpl.loadEnvironmentVariables(ctx, 2, repositories)
+		// Call loadEnvironmentVariablesForEnvironmentRepository
+		envVars, err := remoteImpl.loadEnvironmentVariablesForEnvironmentRepository(ctx, "test-repo", "production")
 
 		// Verify no errors occurred
 		assert.NoError(t, err)
 		assert.NotNil(t, envVars)
-		assert.Equal(t, 3, len(envVars))
+		assert.Equal(t, 1, len(envVars))
+		assert.Equal(t, "value1", envVars["VAR1"])
 
-		// Verify all repositories were processed
-		assert.NotNil(t, envVars["repo1"])
-		assert.NotNil(t, envVars["repo2"])
-		assert.NotNil(t, envVars["repo3"])
+		// Verify API call was made correctly
+		assert.Equal(t, 2, mockClient.callCount)
+		assert.Equal(t, "/repos/myorg/test-repo/environments/production/variables", mockClient.lastEndpoint)
+		assert.Equal(t, "page=1&per_page=30", mockClient.lastParameters)
+		assert.Equal(t, "GET", mockClient.lastMethod)
 
-		// Verify rate limiting was applied (max 2 concurrent goroutines)
-		assert.LessOrEqual(t, mockClient.callCount, 6) // 3 repositories * 2 environments
+	})
+
+	t.Run("happy path: lazy loading of environment variables", func(t *testing.T) {
+		// Setup mock client
+		mockClient := &LoadEnvironmentVariablesMockClient{
+			responseBody: `{
+				"total_count": 2,
+				"variables": [
+					{
+						"name": "VAR1",
+						"value": "value1",
+						"created_at": "2023-01-01T00:00:00Z",
+						"updated_at": "2023-01-01T00:00:00Z"
+					},
+					{
+						"name": "VAR2",
+						"value": "value2",
+						"created_at": "2023-01-01T00:00:00Z",
+						"updated_at": "2023-01-01T00:00:00Z"
+					}
+				]
+			}`,
+		}
+
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true)
+		ctx := context.TODO()
+
+		// Create a repository with an environment
+		repo := &GithubRepository{
+			Name: "test-repo",
+			Id:   123,
+			Environments: NewRemoteLazyLoader[*GithubEnvironment](func() map[string]*GithubEnvironment {
+				envs := make(map[string]*GithubEnvironment)
+				envs["production"] = &GithubEnvironment{
+					Name:      "production",
+					Variables: map[string]string{},
+				}
+				return envs
+			}),
+		}
+
+		// Initially, only 1 call should have been made (getGHESVersion)
+		assert.Equal(t, 1, mockClient.callCount)
+
+		// Get the environment
+		envs := repo.Environments.GetEntity()
+		assert.NotNil(t, envs)
+		assert.Equal(t, 1, len(envs))
+		assert.NotNil(t, envs["production"])
+
+		// Still only 1 call should have been made (getGHESVersion)
+		assert.Equal(t, 1, mockClient.callCount)
+
+		// Now load the environment variables
+		envVars, err := remoteImpl.loadEnvironmentVariablesForEnvironmentRepository(ctx, repo.Name, "production")
+		assert.NoError(t, err)
+		assert.NotNil(t, envVars)
+		assert.Equal(t, 2, len(envVars))
+		assert.Equal(t, "value1", envVars["VAR1"])
+		assert.Equal(t, "value2", envVars["VAR2"])
+
+		// Now API calls should have been made
+		assert.Equal(t, 2, mockClient.callCount)
+		assert.Equal(t, "/repos/myorg/test-repo/environments/production/variables", mockClient.lastEndpoint)
+		assert.Equal(t, "page=1&per_page=30", mockClient.lastParameters)
+		assert.Equal(t, "GET", mockClient.lastMethod)
+
+		// Update the environment variables in the repository
+		envs["production"].Variables = envVars
+
+		// Verify the variables are now accessible through the repository
+		assert.Equal(t, "value1", envs["production"].Variables["VAR1"])
+		assert.Equal(t, "value2", envs["production"].Variables["VAR2"])
+	})
+}
+
+func TestAddRepositoryEnvironment(t *testing.T) {
+	t.Run("happy path: add new environment to repository", func(t *testing.T) {
+		// Setup mock client
+		mockClient := &LoadEnvironmentVariablesMockClient{}
+
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true)
+		ctx := context.TODO()
+		errorCollector := observability.NewErrorCollection()
+
+		// Create a repository
+		repo := &GithubRepository{
+			Name: "test-repo",
+			Id:   123,
+			Environments: NewRemoteLazyLoader[*GithubEnvironment](func() map[string]*GithubEnvironment {
+				return make(map[string]*GithubEnvironment)
+			}),
+		}
+		remoteImpl.repositories = map[string]*GithubRepository{
+			"test-repo": repo,
+		}
+
+		// Add environment
+		remoteImpl.AddRepositoryEnvironment(ctx, errorCollector, false, "test-repo", "production")
+
+		// Verify no errors occurred
+		assert.Empty(t, errorCollector.Errors)
+
+		// Verify API call was made correctly
+		assert.Equal(t, 3, mockClient.callCount) // 1 for getGHESVersion, 1 for adding environment
+		assert.Equal(t, "/repos/myorg/test-repo/environments/production", mockClient.lastEndpoint)
+		assert.Equal(t, "", mockClient.lastParameters)
+		assert.Equal(t, "PUT", mockClient.lastMethod)
+		assert.Nil(t, mockClient.lastBody)
+
+		// Verify environment was added to repository
+		envs := repo.Environments.GetEntity()
+		assert.NotNil(t, envs)
+		assert.Equal(t, 1, len(envs))
+		assert.NotNil(t, envs["production"])
+		assert.Equal(t, "production", envs["production"].Name)
+		assert.Empty(t, envs["production"].Variables)
+	})
+
+	t.Run("error path: repository not found", func(t *testing.T) {
+		mockClient := &LoadEnvironmentVariablesMockClient{}
+
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true)
+		ctx := context.TODO()
+		errorCollector := observability.NewErrorCollection()
+
+		// Try to add environment to non-existent repository
+		remoteImpl.AddRepositoryEnvironment(ctx, errorCollector, false, "non-existent", "production")
+
+		// Verify error was collected
+		assert.NotEmpty(t, errorCollector.Errors)
+		assert.Contains(t, errorCollector.Errors[0].Error(), "repository non-existent not found")
+
+		// Verify no API calls were made
+		assert.Equal(t, 2, mockClient.callCount) // Only getGHESVersion
+	})
+
+	t.Run("error path: environment already exists", func(t *testing.T) {
+		mockClient := &LoadEnvironmentVariablesMockClient{}
+
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true)
+		ctx := context.TODO()
+		errorCollector := observability.NewErrorCollection()
+
+		// Create a repository with existing environment
+		repo := &GithubRepository{
+			Name: "test-repo",
+			Id:   123,
+			Environments: NewRemoteLazyLoader[*GithubEnvironment](func() map[string]*GithubEnvironment {
+				envs := make(map[string]*GithubEnvironment)
+				envs["production"] = &GithubEnvironment{
+					Name:      "production",
+					Variables: map[string]string{},
+				}
+				return envs
+			}),
+		}
+		remoteImpl.repositories = map[string]*GithubRepository{
+			"test-repo": repo,
+		}
+
+		// Try to add existing environment
+		remoteImpl.AddRepositoryEnvironment(ctx, errorCollector, false, "test-repo", "production")
+
+		// Verify error was collected
+		assert.NotEmpty(t, errorCollector.Errors)
+		assert.Contains(t, errorCollector.Errors[0].Error(), "environment production already exists")
+
+		// Verify no API calls were made
+		assert.Equal(t, 2, mockClient.callCount) // Only getGHESVersion
+	})
+
+	t.Run("happy path: dry run mode", func(t *testing.T) {
+		mockClient := &LoadEnvironmentVariablesMockClient{}
+
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true)
+		ctx := context.TODO()
+		errorCollector := observability.NewErrorCollection()
+
+		// Create a repository
+		repo := &GithubRepository{
+			Name: "test-repo",
+			Id:   123,
+			Environments: NewRemoteLazyLoader[*GithubEnvironment](func() map[string]*GithubEnvironment {
+				return make(map[string]*GithubEnvironment)
+			}),
+		}
+		remoteImpl.repositories = map[string]*GithubRepository{
+			"test-repo": repo,
+		}
+
+		// Add environment in dry run mode
+		remoteImpl.AddRepositoryEnvironment(ctx, errorCollector, true, "test-repo", "production")
+
+		// Verify no errors occurred
+		assert.Empty(t, errorCollector.Errors)
+
+		// Verify no API calls were made
+		assert.Equal(t, 2, mockClient.callCount) // Only getGHESVersion
+
+		// Verify environment was added to repository
+		envs := repo.Environments.GetEntity()
+		assert.NotNil(t, envs)
+		assert.Equal(t, 1, len(envs))
+		assert.NotNil(t, envs["production"])
+		assert.Equal(t, "production", envs["production"].Name)
+		assert.Empty(t, envs["production"].Variables)
+	})
+
+	t.Run("error path: API error", func(t *testing.T) {
+		mockClient := &LoadEnvironmentVariablesMockClient{
+			shouldError:  true,
+			errorMessage: "API error",
+		}
+
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true)
+		ctx := context.TODO()
+		errorCollector := observability.NewErrorCollection()
+
+		// Create a repository
+		repo := &GithubRepository{
+			Name: "test-repo",
+			Id:   123,
+			Environments: NewRemoteLazyLoader[*GithubEnvironment](func() map[string]*GithubEnvironment {
+				return make(map[string]*GithubEnvironment)
+			}),
+		}
+		remoteImpl.repositories = map[string]*GithubRepository{
+			"test-repo": repo,
+		}
+
+		// Try to add environment
+		remoteImpl.AddRepositoryEnvironment(ctx, errorCollector, false, "test-repo", "production")
+
+		// Verify error was collected
+		assert.NotEmpty(t, errorCollector.Errors)
+		assert.Contains(t, errorCollector.Errors[0].Error(), "API error")
+
+		// Verify API call was made
+		assert.Equal(t, 3, mockClient.callCount) // 1 for getGHESVersion, 1 for adding environment
+		assert.Equal(t, "/repos/myorg/test-repo/environments/production", mockClient.lastEndpoint)
+		assert.Equal(t, "", mockClient.lastParameters)
+		assert.Equal(t, "PUT", mockClient.lastMethod)
+		assert.Nil(t, mockClient.lastBody)
+
+		// Verify environment was not added to repository
+		envs := repo.Environments.GetEntity()
+		assert.NotNil(t, envs)
+		assert.Empty(t, envs)
+	})
+}
+
+func TestDeleteRepositoryEnvironment(t *testing.T) {
+	t.Run("happy path: delete existing environment from repository", func(t *testing.T) {
+		// Setup mock client
+		mockClient := &LoadEnvironmentVariablesMockClient{}
+
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true)
+		ctx := context.TODO()
+		errorCollector := observability.NewErrorCollection()
+
+		// Create a repository with an environment
+		repo := &GithubRepository{
+			Name: "test-repo",
+			Id:   123,
+			Environments: NewRemoteLazyLoader[*GithubEnvironment](func() map[string]*GithubEnvironment {
+				envs := make(map[string]*GithubEnvironment)
+				envs["production"] = &GithubEnvironment{
+					Name:      "production",
+					Variables: map[string]string{},
+				}
+				return envs
+			}),
+		}
+		remoteImpl.repositories = map[string]*GithubRepository{
+			"test-repo": repo,
+		}
+
+		// Delete environment
+		remoteImpl.DeleteRepositoryEnvironment(ctx, errorCollector, false, "test-repo", "production")
+
+		// Verify no errors occurred
+		assert.Empty(t, errorCollector.Errors)
+
+		// Verify API call was made correctly
+		assert.Equal(t, 3, mockClient.callCount) // 1 for getGHESVersion, 1 for deleting environment
+		assert.Equal(t, "/repos/myorg/test-repo/environments/production", mockClient.lastEndpoint)
+		assert.Equal(t, "", mockClient.lastParameters)
+		assert.Equal(t, "DELETE", mockClient.lastMethod)
+		assert.Nil(t, mockClient.lastBody)
+
+		// Verify environment was removed from repository
+		envs := repo.Environments.GetEntity()
+		assert.NotNil(t, envs)
+		assert.Empty(t, envs)
+	})
+
+	t.Run("error path: repository not found", func(t *testing.T) {
+		mockClient := &LoadEnvironmentVariablesMockClient{}
+
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true)
+		ctx := context.TODO()
+		errorCollector := observability.NewErrorCollection()
+
+		// Try to delete environment from non-existent repository
+		remoteImpl.DeleteRepositoryEnvironment(ctx, errorCollector, false, "non-existent", "production")
+
+		// Verify error was collected
+		assert.NotEmpty(t, errorCollector.Errors)
+		assert.Contains(t, errorCollector.Errors[0].Error(), "repository non-existent not found")
+
+		// Verify no API calls were made
+		assert.Equal(t, 2, mockClient.callCount) // Only getGHESVersion
+	})
+
+	t.Run("error path: environment not found", func(t *testing.T) {
+		mockClient := &LoadEnvironmentVariablesMockClient{}
+
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true)
+		ctx := context.TODO()
+		errorCollector := observability.NewErrorCollection()
+
+		// Create a repository without the environment
+		repo := &GithubRepository{
+			Name: "test-repo",
+			Id:   123,
+			Environments: NewRemoteLazyLoader[*GithubEnvironment](func() map[string]*GithubEnvironment {
+				return make(map[string]*GithubEnvironment)
+			}),
+		}
+		remoteImpl.repositories = map[string]*GithubRepository{
+			"test-repo": repo,
+		}
+
+		// Try to delete non-existent environment
+		remoteImpl.DeleteRepositoryEnvironment(ctx, errorCollector, false, "test-repo", "production")
+
+		// Verify error was collected
+		assert.NotEmpty(t, errorCollector.Errors)
+		assert.Contains(t, errorCollector.Errors[0].Error(), "environment production not found")
+
+		// Verify no API calls were made
+		assert.Equal(t, 2, mockClient.callCount) // Only getGHESVersion
+	})
+
+	t.Run("happy path: dry run mode", func(t *testing.T) {
+		mockClient := &LoadEnvironmentVariablesMockClient{}
+
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true)
+		ctx := context.TODO()
+		errorCollector := observability.NewErrorCollection()
+
+		// Create a repository with an environment
+		repo := &GithubRepository{
+			Name: "test-repo",
+			Id:   123,
+			Environments: NewRemoteLazyLoader[*GithubEnvironment](func() map[string]*GithubEnvironment {
+				envs := make(map[string]*GithubEnvironment)
+				envs["production"] = &GithubEnvironment{
+					Name:      "production",
+					Variables: map[string]string{},
+				}
+				return envs
+			}),
+		}
+		remoteImpl.repositories = map[string]*GithubRepository{
+			"test-repo": repo,
+		}
+
+		// Delete environment in dry run mode
+		remoteImpl.DeleteRepositoryEnvironment(ctx, errorCollector, true, "test-repo", "production")
+
+		// Verify no errors occurred
+		assert.Empty(t, errorCollector.Errors)
+
+		// Verify no API calls were made
+		assert.Equal(t, 2, mockClient.callCount) // Only getGHESVersion
+
+		// Verify environment was removed from repository
+		envs := repo.Environments.GetEntity()
+		assert.NotNil(t, envs)
+		assert.Empty(t, envs)
+	})
+
+	t.Run("error path: API error", func(t *testing.T) {
+		mockClient := &LoadEnvironmentVariablesMockClient{
+			shouldError:  true,
+			errorMessage: "API error",
+		}
+
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true)
+		ctx := context.TODO()
+		errorCollector := observability.NewErrorCollection()
+
+		// Create a repository with an environment
+		repo := &GithubRepository{
+			Name: "test-repo",
+			Id:   123,
+			Environments: NewRemoteLazyLoader[*GithubEnvironment](func() map[string]*GithubEnvironment {
+				envs := make(map[string]*GithubEnvironment)
+				envs["production"] = &GithubEnvironment{
+					Name:      "production",
+					Variables: map[string]string{},
+				}
+				return envs
+			}),
+		}
+		remoteImpl.repositories = map[string]*GithubRepository{
+			"test-repo": repo,
+		}
+
+		// Try to delete environment
+		remoteImpl.DeleteRepositoryEnvironment(ctx, errorCollector, false, "test-repo", "production")
+
+		// Verify error was collected
+		assert.NotEmpty(t, errorCollector.Errors)
+		assert.Contains(t, errorCollector.Errors[0].Error(), "API error")
+
+		// Verify API call was made
+		assert.Equal(t, 3, mockClient.callCount) // 1 for getGHESVersion, 1 for deleting environment
+		assert.Equal(t, "/repos/myorg/test-repo/environments/production", mockClient.lastEndpoint)
+		assert.Equal(t, "", mockClient.lastParameters)
+		assert.Equal(t, "DELETE", mockClient.lastMethod)
+		assert.Nil(t, mockClient.lastBody)
+
+		// Verify environment was not removed from repository
+		envs := repo.Environments.GetEntity()
+		assert.NotNil(t, envs)
+		assert.Equal(t, 1, len(envs))
+		assert.NotNil(t, envs["production"])
+	})
+}
+
+func TestAddRepositoryEnvironmentVariable(t *testing.T) {
+	t.Run("happy path: add new variable to repository environment", func(t *testing.T) {
+		// Setup mock client
+		mockClient := &LoadEnvironmentVariablesMockClient{}
+
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true)
+		ctx := context.TODO()
+		errorCollector := observability.NewErrorCollection()
+
+		// Create a repository with an environment
+		repo := &GithubRepository{
+			Name: "test-repo",
+			Id:   123,
+			Environments: NewRemoteLazyLoader[*GithubEnvironment](func() map[string]*GithubEnvironment {
+				envs := make(map[string]*GithubEnvironment)
+				envs["production"] = &GithubEnvironment{
+					Name:      "production",
+					Variables: map[string]string{},
+				}
+				return envs
+			}),
+		}
+		remoteImpl.repositories = map[string]*GithubRepository{
+			"test-repo": repo,
+		}
+
+		// Add variable
+		remoteImpl.AddRepositoryEnvironmentVariable(ctx, errorCollector, false, "test-repo", "production", "TEST_VAR", "test-value")
+
+		// Verify no errors occurred
+		assert.Empty(t, errorCollector.Errors)
+
+		// Verify API call was made correctly
+		assert.Equal(t, 3, mockClient.callCount) // 1 for getGHESVersion, 1 for adding variable
+		assert.Equal(t, "/repos/myorg/test-repo/environments/production/variables", mockClient.lastEndpoint)
+		assert.Equal(t, "", mockClient.lastParameters)
+		assert.Equal(t, "POST", mockClient.lastMethod)
+		assert.Equal(t, map[string]interface{}{
+			"name":  "TEST_VAR",
+			"value": "test-value",
+		}, mockClient.lastBody)
+
+		// Verify variable was added to repository environment
+		envs := repo.Environments.GetEntity()
+		assert.NotNil(t, envs)
+		assert.Equal(t, 1, len(envs))
+		assert.NotNil(t, envs["production"])
+		assert.Equal(t, "test-value", envs["production"].Variables["TEST_VAR"])
+	})
+
+	t.Run("error path: repository not found", func(t *testing.T) {
+		mockClient := &LoadEnvironmentVariablesMockClient{}
+
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true)
+		ctx := context.TODO()
+		errorCollector := observability.NewErrorCollection()
+
+		// Try to add variable to non-existent repository
+		remoteImpl.AddRepositoryEnvironmentVariable(ctx, errorCollector, false, "non-existent", "production", "TEST_VAR", "test-value")
+
+		// Verify error was collected
+		assert.NotEmpty(t, errorCollector.Errors)
+		assert.Contains(t, errorCollector.Errors[0].Error(), "repository non-existent not found")
+
+		// Verify no API calls were made
+		assert.Equal(t, 2, mockClient.callCount) // Only getGHESVersion
+	})
+
+	t.Run("error path: environment not found", func(t *testing.T) {
+		mockClient := &LoadEnvironmentVariablesMockClient{}
+
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true)
+		ctx := context.TODO()
+		errorCollector := observability.NewErrorCollection()
+
+		// Create a repository without the environment
+		repo := &GithubRepository{
+			Name: "test-repo",
+			Id:   123,
+			Environments: NewRemoteLazyLoader[*GithubEnvironment](func() map[string]*GithubEnvironment {
+				return make(map[string]*GithubEnvironment)
+			}),
+		}
+		remoteImpl.repositories = map[string]*GithubRepository{
+			"test-repo": repo,
+		}
+
+		// Try to add variable to non-existent environment
+		remoteImpl.AddRepositoryEnvironmentVariable(ctx, errorCollector, false, "test-repo", "production", "TEST_VAR", "test-value")
+
+		// Verify error was collected
+		assert.NotEmpty(t, errorCollector.Errors)
+		assert.Contains(t, errorCollector.Errors[0].Error(), "environment production not found")
+
+		// Verify no API calls were made
+		assert.Equal(t, 2, mockClient.callCount) // Only getGHESVersion
+	})
+
+	t.Run("error path: variable already exists", func(t *testing.T) {
+		mockClient := &LoadEnvironmentVariablesMockClient{}
+
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true)
+		ctx := context.TODO()
+		errorCollector := observability.NewErrorCollection()
+
+		// Create a repository with an environment and existing variable
+		repo := &GithubRepository{
+			Name: "test-repo",
+			Id:   123,
+			Environments: NewRemoteLazyLoader[*GithubEnvironment](func() map[string]*GithubEnvironment {
+				envs := make(map[string]*GithubEnvironment)
+				envs["production"] = &GithubEnvironment{
+					Name: "production",
+					Variables: map[string]string{
+						"TEST_VAR": "existing-value",
+					},
+				}
+				return envs
+			}),
+		}
+		remoteImpl.repositories = map[string]*GithubRepository{
+			"test-repo": repo,
+		}
+
+		// Try to add existing variable
+		remoteImpl.AddRepositoryEnvironmentVariable(ctx, errorCollector, false, "test-repo", "production", "TEST_VAR", "new-value")
+
+		// Verify error was collected
+		assert.NotEmpty(t, errorCollector.Errors)
+		assert.Contains(t, errorCollector.Errors[0].Error(), "variable TEST_VAR already exists")
+
+		// Verify no API calls were made
+		assert.Equal(t, 2, mockClient.callCount) // Only getGHESVersion
+	})
+
+	t.Run("happy path: dry run mode", func(t *testing.T) {
+		mockClient := &LoadEnvironmentVariablesMockClient{}
+
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true)
+		ctx := context.TODO()
+		errorCollector := observability.NewErrorCollection()
+
+		// Create a repository with an environment
+		repo := &GithubRepository{
+			Name: "test-repo",
+			Id:   123,
+			Environments: NewRemoteLazyLoader[*GithubEnvironment](func() map[string]*GithubEnvironment {
+				envs := make(map[string]*GithubEnvironment)
+				envs["production"] = &GithubEnvironment{
+					Name:      "production",
+					Variables: map[string]string{},
+				}
+				return envs
+			}),
+		}
+		remoteImpl.repositories = map[string]*GithubRepository{
+			"test-repo": repo,
+		}
+
+		// Add variable in dry run mode
+		remoteImpl.AddRepositoryEnvironmentVariable(ctx, errorCollector, true, "test-repo", "production", "TEST_VAR", "test-value")
+
+		// Verify no errors occurred
+		assert.Empty(t, errorCollector.Errors)
+
+		// Verify no API calls were made
+		assert.Equal(t, 2, mockClient.callCount) // Only getGHESVersion
+
+		// Verify variable was added to repository environment
+		envs := repo.Environments.GetEntity()
+		assert.NotNil(t, envs)
+		assert.Equal(t, 1, len(envs))
+		assert.NotNil(t, envs["production"])
+		assert.Equal(t, "test-value", envs["production"].Variables["TEST_VAR"])
+	})
+
+	t.Run("error path: API error", func(t *testing.T) {
+		mockClient := &LoadEnvironmentVariablesMockClient{
+			shouldError:  true,
+			errorMessage: "API error",
+		}
+
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true)
+		ctx := context.TODO()
+		errorCollector := observability.NewErrorCollection()
+
+		// Create a repository with an environment
+		repo := &GithubRepository{
+			Name: "test-repo",
+			Id:   123,
+			Environments: NewRemoteLazyLoader[*GithubEnvironment](func() map[string]*GithubEnvironment {
+				envs := make(map[string]*GithubEnvironment)
+				envs["production"] = &GithubEnvironment{
+					Name:      "production",
+					Variables: map[string]string{},
+				}
+				return envs
+			}),
+		}
+		remoteImpl.repositories = map[string]*GithubRepository{
+			"test-repo": repo,
+		}
+
+		// Try to add variable
+		remoteImpl.AddRepositoryEnvironmentVariable(ctx, errorCollector, false, "test-repo", "production", "TEST_VAR", "test-value")
+
+		// Verify error was collected
+		assert.NotEmpty(t, errorCollector.Errors)
+		assert.Contains(t, errorCollector.Errors[0].Error(), "API error")
+
+		// Verify API call was made
+		assert.Equal(t, 3, mockClient.callCount) // 1 for getGHESVersion, 1 for adding variable
+		assert.Equal(t, "/repos/myorg/test-repo/environments/production/variables", mockClient.lastEndpoint)
+		assert.Equal(t, "", mockClient.lastParameters)
+		assert.Equal(t, "POST", mockClient.lastMethod)
+		assert.Equal(t, map[string]interface{}{
+			"name":  "TEST_VAR",
+			"value": "test-value",
+		}, mockClient.lastBody)
+
+		// Verify variable was not added to repository environment
+		envs := repo.Environments.GetEntity()
+		assert.NotNil(t, envs)
+		assert.Equal(t, 1, len(envs))
+		assert.NotNil(t, envs["production"])
+		assert.Empty(t, envs["production"].Variables)
+	})
+}
+
+func TestUpdateRepositoryVariable(t *testing.T) {
+	t.Run("happy path: update existing variable in repository", func(t *testing.T) {
+		// Setup mock client
+		mockClient := &LoadEnvironmentVariablesMockClient{}
+
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true)
+		ctx := context.TODO()
+		errorCollector := observability.NewErrorCollection()
+
+		// Create a repository with an existing variable
+		repo := &GithubRepository{
+			Name: "test-repo",
+			Id:   123,
+			RepositoryVariables: NewRemoteLazyLoader[string](func() map[string]string {
+				vars := make(map[string]string)
+				vars["TEST_VAR"] = "old-value"
+				return vars
+			}),
+		}
+		remoteImpl.repositories = map[string]*GithubRepository{
+			"test-repo": repo,
+		}
+
+		// Update variable
+		remoteImpl.UpdateRepositoryVariable(ctx, errorCollector, false, "test-repo", "TEST_VAR", "new-value")
+
+		// Verify no errors occurred
+		assert.Empty(t, errorCollector.Errors)
+
+		// Verify API call was made correctly
+		assert.Equal(t, 3, mockClient.callCount) // 1 for getGHESVersion, 1 for updating variable
+		assert.Equal(t, "/repos/myorg/test-repo/actions/variables/TEST_VAR", mockClient.lastEndpoint)
+		assert.Equal(t, "", mockClient.lastParameters)
+		assert.Equal(t, "PATCH", mockClient.lastMethod)
+		assert.Equal(t, map[string]interface{}{
+			"name":  "TEST_VAR",
+			"value": "new-value",
+		}, mockClient.lastBody)
+
+		// Verify variable was updated in repository
+		vars := repo.RepositoryVariables.GetEntity()
+		assert.NotNil(t, vars)
+		assert.Equal(t, "new-value", vars["TEST_VAR"])
+	})
+
+	t.Run("error path: repository not found", func(t *testing.T) {
+		mockClient := &LoadEnvironmentVariablesMockClient{}
+
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true)
+		ctx := context.TODO()
+		errorCollector := observability.NewErrorCollection()
+
+		// Try to update variable in non-existent repository
+		remoteImpl.UpdateRepositoryVariable(ctx, errorCollector, false, "non-existent", "TEST_VAR", "new-value")
+
+		// Verify error was collected
+		assert.NotEmpty(t, errorCollector.Errors)
+		assert.Contains(t, errorCollector.Errors[0].Error(), "repository non-existent not found")
+
+		// Verify no API calls were made
+		assert.Equal(t, 2, mockClient.callCount) // Only getGHESVersion
+	})
+
+	t.Run("error path: variable not found", func(t *testing.T) {
+		mockClient := &LoadEnvironmentVariablesMockClient{}
+
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true)
+		ctx := context.TODO()
+		errorCollector := observability.NewErrorCollection()
+
+		// Create a repository without the variable
+		repo := &GithubRepository{
+			Name: "test-repo",
+			Id:   123,
+			RepositoryVariables: NewRemoteLazyLoader[string](func() map[string]string {
+				return make(map[string]string)
+			}),
+		}
+		remoteImpl.repositories = map[string]*GithubRepository{
+			"test-repo": repo,
+		}
+
+		// Try to update non-existent variable
+		remoteImpl.UpdateRepositoryVariable(ctx, errorCollector, false, "test-repo", "TEST_VAR", "new-value")
+
+		// Verify error was collected
+		assert.NotEmpty(t, errorCollector.Errors)
+		assert.Contains(t, errorCollector.Errors[0].Error(), "variable TEST_VAR not found")
+
+		// Verify no API calls were made
+		assert.Equal(t, 2, mockClient.callCount) // Only getGHESVersion
+	})
+
+	t.Run("happy path: dry run mode", func(t *testing.T) {
+		mockClient := &LoadEnvironmentVariablesMockClient{}
+
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true)
+		ctx := context.TODO()
+		errorCollector := observability.NewErrorCollection()
+
+		// Create a repository with an existing variable
+		repo := &GithubRepository{
+			Name: "test-repo",
+			Id:   123,
+			RepositoryVariables: NewRemoteLazyLoader[string](func() map[string]string {
+				vars := make(map[string]string)
+				vars["TEST_VAR"] = "old-value"
+				return vars
+			}),
+		}
+		remoteImpl.repositories = map[string]*GithubRepository{
+			"test-repo": repo,
+		}
+
+		// Update variable in dry run mode
+		remoteImpl.UpdateRepositoryVariable(ctx, errorCollector, true, "test-repo", "TEST_VAR", "new-value")
+
+		// Verify no errors occurred
+		assert.Empty(t, errorCollector.Errors)
+
+		// Verify no API calls were made
+		assert.Equal(t, 2, mockClient.callCount) // Only getGHESVersion
+
+		// Verify variable was updated in repository
+		vars := repo.RepositoryVariables.GetEntity()
+		assert.NotNil(t, vars)
+		assert.Equal(t, "new-value", vars["TEST_VAR"])
+	})
+
+	t.Run("error path: API error", func(t *testing.T) {
+		mockClient := &LoadEnvironmentVariablesMockClient{
+			shouldError:  true,
+			errorMessage: "API error",
+		}
+
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true)
+		ctx := context.TODO()
+		errorCollector := observability.NewErrorCollection()
+
+		// Create a repository with an existing variable
+		repo := &GithubRepository{
+			Name: "test-repo",
+			Id:   123,
+			RepositoryVariables: NewRemoteLazyLoader[string](func() map[string]string {
+				vars := make(map[string]string)
+				vars["TEST_VAR"] = "old-value"
+				return vars
+			}),
+		}
+		remoteImpl.repositories = map[string]*GithubRepository{
+			"test-repo": repo,
+		}
+
+		// Try to update variable
+		remoteImpl.UpdateRepositoryVariable(ctx, errorCollector, false, "test-repo", "TEST_VAR", "new-value")
+
+		// Verify error was collected
+		assert.NotEmpty(t, errorCollector.Errors)
+		assert.Contains(t, errorCollector.Errors[0].Error(), "API error")
+
+		// Verify API call was made
+		assert.Equal(t, 3, mockClient.callCount) // 1 for getGHESVersion, 1 for updating variable
+		assert.Equal(t, "/repos/myorg/test-repo/actions/variables/TEST_VAR", mockClient.lastEndpoint)
+		assert.Equal(t, "", mockClient.lastParameters)
+		assert.Equal(t, "PATCH", mockClient.lastMethod)
+		assert.Equal(t, map[string]interface{}{
+			"name":  "TEST_VAR",
+			"value": "new-value",
+		}, mockClient.lastBody)
+
+		// Verify variable was not updated in repository
+		vars := repo.RepositoryVariables.GetEntity()
+		assert.NotNil(t, vars)
+		assert.Equal(t, "old-value", vars["TEST_VAR"])
+	})
+}
+
+func TestDeleteRepositoryVariable(t *testing.T) {
+	t.Run("happy path: delete existing variable from repository", func(t *testing.T) {
+		// Setup mock client
+		mockClient := &LoadEnvironmentVariablesMockClient{}
+
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true)
+		ctx := context.TODO()
+		errorCollector := observability.NewErrorCollection()
+
+		// Create a repository with an existing variable
+		repo := &GithubRepository{
+			Name: "test-repo",
+			Id:   123,
+			RepositoryVariables: NewRemoteLazyLoader[string](func() map[string]string {
+				vars := make(map[string]string)
+				vars["TEST_VAR"] = "value"
+				return vars
+			}),
+		}
+		remoteImpl.repositories = map[string]*GithubRepository{
+			"test-repo": repo,
+		}
+
+		// Delete variable
+		remoteImpl.DeleteRepositoryVariable(ctx, errorCollector, false, "test-repo", "TEST_VAR")
+
+		// Verify no errors occurred
+		assert.Empty(t, errorCollector.Errors)
+
+		// Verify API call was made correctly
+		assert.Equal(t, 3, mockClient.callCount) // 1 for getGHESVersion, 1 for deleting variable
+		assert.Equal(t, "/repos/myorg/test-repo/actions/variables/TEST_VAR", mockClient.lastEndpoint)
+		assert.Equal(t, "", mockClient.lastParameters)
+		assert.Equal(t, "DELETE", mockClient.lastMethod)
+		assert.Nil(t, mockClient.lastBody)
+
+		// Verify variable was removed from repository
+		vars := repo.RepositoryVariables.GetEntity()
+		assert.NotNil(t, vars)
+		assert.Empty(t, vars)
+	})
+
+	t.Run("error path: repository not found", func(t *testing.T) {
+		mockClient := &LoadEnvironmentVariablesMockClient{}
+
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true)
+		ctx := context.TODO()
+		errorCollector := observability.NewErrorCollection()
+
+		// Try to delete variable from non-existent repository
+		remoteImpl.DeleteRepositoryVariable(ctx, errorCollector, false, "non-existent", "TEST_VAR")
+
+		// Verify error was collected
+		assert.NotEmpty(t, errorCollector.Errors)
+		assert.Contains(t, errorCollector.Errors[0].Error(), "repository non-existent not found")
+
+		// Verify no API calls were made
+		assert.Equal(t, 2, mockClient.callCount) // Only getGHESVersion
+	})
+
+	t.Run("error path: variable not found", func(t *testing.T) {
+		mockClient := &LoadEnvironmentVariablesMockClient{}
+
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true)
+		ctx := context.TODO()
+		errorCollector := observability.NewErrorCollection()
+
+		// Create a repository without the variable
+		repo := &GithubRepository{
+			Name: "test-repo",
+			Id:   123,
+			RepositoryVariables: NewRemoteLazyLoader[string](func() map[string]string {
+				return make(map[string]string)
+			}),
+		}
+		remoteImpl.repositories = map[string]*GithubRepository{
+			"test-repo": repo,
+		}
+
+		// Try to delete non-existent variable
+		remoteImpl.DeleteRepositoryVariable(ctx, errorCollector, false, "test-repo", "TEST_VAR")
+
+		// Verify error was collected
+		assert.NotEmpty(t, errorCollector.Errors)
+		assert.Contains(t, errorCollector.Errors[0].Error(), "variable TEST_VAR not found")
+
+		// Verify no API calls were made
+		assert.Equal(t, 2, mockClient.callCount) // Only getGHESVersion
+	})
+
+	t.Run("happy path: dry run mode", func(t *testing.T) {
+		mockClient := &LoadEnvironmentVariablesMockClient{}
+
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true)
+		ctx := context.TODO()
+		errorCollector := observability.NewErrorCollection()
+
+		// Create a repository with an existing variable
+		repo := &GithubRepository{
+			Name: "test-repo",
+			Id:   123,
+			RepositoryVariables: NewRemoteLazyLoader[string](func() map[string]string {
+				vars := make(map[string]string)
+				vars["TEST_VAR"] = "value"
+				return vars
+			}),
+		}
+		remoteImpl.repositories = map[string]*GithubRepository{
+			"test-repo": repo,
+		}
+
+		// Delete variable in dry run mode
+		remoteImpl.DeleteRepositoryVariable(ctx, errorCollector, true, "test-repo", "TEST_VAR")
+
+		// Verify no errors occurred
+		assert.Empty(t, errorCollector.Errors)
+
+		// Verify no API calls were made
+		assert.Equal(t, 2, mockClient.callCount) // Only getGHESVersion
+
+		// Verify variable was removed from repository
+		vars := repo.RepositoryVariables.GetEntity()
+		assert.NotNil(t, vars)
+		assert.Empty(t, vars)
+	})
+
+	t.Run("error path: API error", func(t *testing.T) {
+		mockClient := &LoadEnvironmentVariablesMockClient{
+			shouldError:  true,
+			errorMessage: "API error",
+		}
+
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true)
+		ctx := context.TODO()
+		errorCollector := observability.NewErrorCollection()
+
+		// Create a repository with an existing variable
+		repo := &GithubRepository{
+			Name: "test-repo",
+			Id:   123,
+			RepositoryVariables: NewRemoteLazyLoader[string](func() map[string]string {
+				vars := make(map[string]string)
+				vars["TEST_VAR"] = "value"
+				return vars
+			}),
+		}
+		remoteImpl.repositories = map[string]*GithubRepository{
+			"test-repo": repo,
+		}
+
+		// Try to delete variable
+		remoteImpl.DeleteRepositoryVariable(ctx, errorCollector, false, "test-repo", "TEST_VAR")
+
+		// Verify error was collected
+		assert.NotEmpty(t, errorCollector.Errors)
+		assert.Contains(t, errorCollector.Errors[0].Error(), "API error")
+
+		// Verify API call was made
+		assert.Equal(t, 3, mockClient.callCount) // 1 for getGHESVersion, 1 for deleting variable
+		assert.Equal(t, "/repos/myorg/test-repo/actions/variables/TEST_VAR", mockClient.lastEndpoint)
+		assert.Equal(t, "", mockClient.lastParameters)
+		assert.Equal(t, "DELETE", mockClient.lastMethod)
+		assert.Nil(t, mockClient.lastBody)
+
+		// Verify variable was not removed from repository
+		vars := repo.RepositoryVariables.GetEntity()
+		assert.NotNil(t, vars)
+		assert.Equal(t, "value", vars["TEST_VAR"])
+	})
+}
+
+func TestUpdateRepositoryEnvironmentVariable(t *testing.T) {
+	t.Run("happy path: update existing variable in repository environment", func(t *testing.T) {
+		// Setup mock client
+		mockClient := &LoadEnvironmentVariablesMockClient{}
+
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true)
+		ctx := context.TODO()
+		errorCollector := observability.NewErrorCollection()
+
+		// Create a repository with an environment and existing variable
+		repo := &GithubRepository{
+			Name: "test-repo",
+			Id:   123,
+			Environments: NewRemoteLazyLoader[*GithubEnvironment](func() map[string]*GithubEnvironment {
+				envs := make(map[string]*GithubEnvironment)
+				envs["production"] = &GithubEnvironment{
+					Name: "production",
+					Variables: map[string]string{
+						"TEST_VAR": "old-value",
+					},
+				}
+				return envs
+			}),
+		}
+		remoteImpl.repositories = map[string]*GithubRepository{
+			"test-repo": repo,
+		}
+
+		// Update variable
+		remoteImpl.UpdateRepositoryEnvironmentVariable(ctx, errorCollector, false, "test-repo", "production", "TEST_VAR", "new-value")
+
+		// Verify no errors occurred
+		assert.Empty(t, errorCollector.Errors)
+
+		// Verify API call was made correctly
+		assert.Equal(t, 3, mockClient.callCount) // 1 for getGHESVersion, 1 for updating variable
+		assert.Equal(t, "/repos/myorg/test-repo/environments/production/variables/TEST_VAR", mockClient.lastEndpoint)
+		assert.Equal(t, "", mockClient.lastParameters)
+		assert.Equal(t, "PATCH", mockClient.lastMethod)
+		assert.Equal(t, map[string]interface{}{
+			"name":  "TEST_VAR",
+			"value": "new-value",
+		}, mockClient.lastBody)
+
+		// Verify variable was updated in repository environment
+		envs := repo.Environments.GetEntity()
+		assert.NotNil(t, envs)
+		assert.Equal(t, 1, len(envs))
+		assert.NotNil(t, envs["production"])
+		assert.Equal(t, "new-value", envs["production"].Variables["TEST_VAR"])
+	})
+
+	t.Run("error path: repository not found", func(t *testing.T) {
+		mockClient := &LoadEnvironmentVariablesMockClient{}
+
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true)
+		ctx := context.TODO()
+		errorCollector := observability.NewErrorCollection()
+
+		// Try to update variable in non-existent repository
+		remoteImpl.UpdateRepositoryEnvironmentVariable(ctx, errorCollector, false, "non-existent", "production", "TEST_VAR", "new-value")
+
+		// Verify error was collected
+		assert.NotEmpty(t, errorCollector.Errors)
+		assert.Contains(t, errorCollector.Errors[0].Error(), "repository non-existent not found")
+
+		// Verify no API calls were made
+		assert.Equal(t, 2, mockClient.callCount) // Only getGHESVersion
+	})
+
+	t.Run("error path: environment not found", func(t *testing.T) {
+		mockClient := &LoadEnvironmentVariablesMockClient{}
+
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true)
+		ctx := context.TODO()
+		errorCollector := observability.NewErrorCollection()
+
+		// Create a repository without the environment
+		repo := &GithubRepository{
+			Name: "test-repo",
+			Id:   123,
+			Environments: NewRemoteLazyLoader[*GithubEnvironment](func() map[string]*GithubEnvironment {
+				return make(map[string]*GithubEnvironment)
+			}),
+		}
+		remoteImpl.repositories = map[string]*GithubRepository{
+			"test-repo": repo,
+		}
+
+		// Try to update variable in non-existent environment
+		remoteImpl.UpdateRepositoryEnvironmentVariable(ctx, errorCollector, false, "test-repo", "production", "TEST_VAR", "new-value")
+
+		// Verify error was collected
+		assert.NotEmpty(t, errorCollector.Errors)
+		assert.Contains(t, errorCollector.Errors[0].Error(), "environment production not found")
+
+		// Verify no API calls were made
+		assert.Equal(t, 2, mockClient.callCount) // Only getGHESVersion
+	})
+
+	t.Run("error path: variable not found", func(t *testing.T) {
+		mockClient := &LoadEnvironmentVariablesMockClient{}
+
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true)
+		ctx := context.TODO()
+		errorCollector := observability.NewErrorCollection()
+
+		// Create a repository with an environment but without the variable
+		repo := &GithubRepository{
+			Name: "test-repo",
+			Id:   123,
+			Environments: NewRemoteLazyLoader[*GithubEnvironment](func() map[string]*GithubEnvironment {
+				envs := make(map[string]*GithubEnvironment)
+				envs["production"] = &GithubEnvironment{
+					Name:      "production",
+					Variables: map[string]string{},
+				}
+				return envs
+			}),
+		}
+		remoteImpl.repositories = map[string]*GithubRepository{
+			"test-repo": repo,
+		}
+
+		// Try to update non-existent variable
+		remoteImpl.UpdateRepositoryEnvironmentVariable(ctx, errorCollector, false, "test-repo", "production", "TEST_VAR", "new-value")
+
+		// Verify error was collected
+		assert.NotEmpty(t, errorCollector.Errors)
+		assert.Contains(t, errorCollector.Errors[0].Error(), "variable TEST_VAR not found")
+
+		// Verify no API calls were made
+		assert.Equal(t, 2, mockClient.callCount) // Only getGHESVersion
+	})
+
+	t.Run("happy path: dry run mode", func(t *testing.T) {
+		mockClient := &LoadEnvironmentVariablesMockClient{}
+
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true)
+		ctx := context.TODO()
+		errorCollector := observability.NewErrorCollection()
+
+		// Create a repository with an environment and existing variable
+		repo := &GithubRepository{
+			Name: "test-repo",
+			Id:   123,
+			Environments: NewRemoteLazyLoader[*GithubEnvironment](func() map[string]*GithubEnvironment {
+				envs := make(map[string]*GithubEnvironment)
+				envs["production"] = &GithubEnvironment{
+					Name: "production",
+					Variables: map[string]string{
+						"TEST_VAR": "old-value",
+					},
+				}
+				return envs
+			}),
+		}
+		remoteImpl.repositories = map[string]*GithubRepository{
+			"test-repo": repo,
+		}
+
+		// Update variable in dry run mode
+		remoteImpl.UpdateRepositoryEnvironmentVariable(ctx, errorCollector, true, "test-repo", "production", "TEST_VAR", "new-value")
+
+		// Verify no errors occurred
+		assert.Empty(t, errorCollector.Errors)
+
+		// Verify no API calls were made
+		assert.Equal(t, 2, mockClient.callCount) // Only getGHESVersion
+
+		// Verify variable was updated in repository environment
+		envs := repo.Environments.GetEntity()
+		assert.NotNil(t, envs)
+		assert.Equal(t, 1, len(envs))
+		assert.NotNil(t, envs["production"])
+		assert.Equal(t, "new-value", envs["production"].Variables["TEST_VAR"])
+	})
+
+	t.Run("error path: API error", func(t *testing.T) {
+		mockClient := &LoadEnvironmentVariablesMockClient{
+			shouldError:  true,
+			errorMessage: "API error",
+		}
+
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true)
+		ctx := context.TODO()
+		errorCollector := observability.NewErrorCollection()
+
+		// Create a repository with an environment and existing variable
+		repo := &GithubRepository{
+			Name: "test-repo",
+			Id:   123,
+			Environments: NewRemoteLazyLoader[*GithubEnvironment](func() map[string]*GithubEnvironment {
+				envs := make(map[string]*GithubEnvironment)
+				envs["production"] = &GithubEnvironment{
+					Name: "production",
+					Variables: map[string]string{
+						"TEST_VAR": "old-value",
+					},
+				}
+				return envs
+			}),
+		}
+		remoteImpl.repositories = map[string]*GithubRepository{
+			"test-repo": repo,
+		}
+
+		// Try to update variable
+		remoteImpl.UpdateRepositoryEnvironmentVariable(ctx, errorCollector, false, "test-repo", "production", "TEST_VAR", "new-value")
+
+		// Verify error was collected
+		assert.NotEmpty(t, errorCollector.Errors)
+		assert.Contains(t, errorCollector.Errors[0].Error(), "API error")
+
+		// Verify API call was made
+		assert.Equal(t, 3, mockClient.callCount) // 1 for getGHESVersion, 1 for updating variable
+		assert.Equal(t, "/repos/myorg/test-repo/environments/production/variables/TEST_VAR", mockClient.lastEndpoint)
+		assert.Equal(t, "", mockClient.lastParameters)
+		assert.Equal(t, "PATCH", mockClient.lastMethod)
+		assert.Equal(t, map[string]interface{}{
+			"name":  "TEST_VAR",
+			"value": "new-value",
+		}, mockClient.lastBody)
+
+		// Verify variable was not updated in repository environment
+		envs := repo.Environments.GetEntity()
+		assert.NotNil(t, envs)
+		assert.Equal(t, 1, len(envs))
+		assert.NotNil(t, envs["production"])
+		assert.Equal(t, "old-value", envs["production"].Variables["TEST_VAR"])
+	})
+}
+
+func TestDeleteRepositoryEnvironmentVariable(t *testing.T) {
+	t.Run("happy path: delete existing variable from repository environment", func(t *testing.T) {
+		// Setup mock client
+		mockClient := &LoadEnvironmentVariablesMockClient{}
+
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true)
+		ctx := context.TODO()
+		errorCollector := observability.NewErrorCollection()
+
+		// Create a repository with an environment and existing variable
+		repo := &GithubRepository{
+			Name: "test-repo",
+			Id:   123,
+			Environments: NewRemoteLazyLoader[*GithubEnvironment](func() map[string]*GithubEnvironment {
+				envs := make(map[string]*GithubEnvironment)
+				envs["production"] = &GithubEnvironment{
+					Name: "production",
+					Variables: map[string]string{
+						"TEST_VAR": "value",
+					},
+				}
+				return envs
+			}),
+		}
+		remoteImpl.repositories = map[string]*GithubRepository{
+			"test-repo": repo,
+		}
+
+		// Delete variable
+		remoteImpl.DeleteRepositoryEnvironmentVariable(ctx, errorCollector, false, "test-repo", "production", "TEST_VAR")
+
+		// Verify no errors occurred
+		assert.Empty(t, errorCollector.Errors)
+
+		// Verify API call was made correctly
+		assert.Equal(t, 3, mockClient.callCount) // 1 for getGHESVersion, 1 for deleting variable
+		assert.Equal(t, "/repos/myorg/test-repo/environments/production/variables/TEST_VAR", mockClient.lastEndpoint)
+		assert.Equal(t, "", mockClient.lastParameters)
+		assert.Equal(t, "DELETE", mockClient.lastMethod)
+		assert.Nil(t, mockClient.lastBody)
+
+		// Verify variable was removed from repository environment
+		envs := repo.Environments.GetEntity()
+		assert.NotNil(t, envs)
+		assert.Equal(t, 1, len(envs))
+		assert.NotNil(t, envs["production"])
+		assert.Empty(t, envs["production"].Variables)
+	})
+
+	t.Run("error path: repository not found", func(t *testing.T) {
+		mockClient := &LoadEnvironmentVariablesMockClient{}
+
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true)
+		ctx := context.TODO()
+		errorCollector := observability.NewErrorCollection()
+
+		// Try to delete variable from non-existent repository
+		remoteImpl.DeleteRepositoryEnvironmentVariable(ctx, errorCollector, false, "non-existent", "production", "TEST_VAR")
+
+		// Verify error was collected
+		assert.NotEmpty(t, errorCollector.Errors)
+		assert.Contains(t, errorCollector.Errors[0].Error(), "repository non-existent not found")
+
+		// Verify no API calls were made
+		assert.Equal(t, 2, mockClient.callCount) // Only getGHESVersion
+	})
+
+	t.Run("error path: environment not found", func(t *testing.T) {
+		mockClient := &LoadEnvironmentVariablesMockClient{}
+
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true)
+		ctx := context.TODO()
+		errorCollector := observability.NewErrorCollection()
+
+		// Create a repository without the environment
+		repo := &GithubRepository{
+			Name: "test-repo",
+			Id:   123,
+			Environments: NewRemoteLazyLoader[*GithubEnvironment](func() map[string]*GithubEnvironment {
+				return make(map[string]*GithubEnvironment)
+			}),
+		}
+		remoteImpl.repositories = map[string]*GithubRepository{
+			"test-repo": repo,
+		}
+
+		// Try to delete variable from non-existent environment
+		remoteImpl.DeleteRepositoryEnvironmentVariable(ctx, errorCollector, false, "test-repo", "production", "TEST_VAR")
+
+		// Verify error was collected
+		assert.NotEmpty(t, errorCollector.Errors)
+		assert.Contains(t, errorCollector.Errors[0].Error(), "environment production not found")
+
+		// Verify no API calls were made
+		assert.Equal(t, 2, mockClient.callCount) // Only getGHESVersion
+	})
+
+	t.Run("error path: variable not found", func(t *testing.T) {
+		mockClient := &LoadEnvironmentVariablesMockClient{}
+
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true)
+		ctx := context.TODO()
+		errorCollector := observability.NewErrorCollection()
+
+		// Create a repository with an environment but without the variable
+		repo := &GithubRepository{
+			Name: "test-repo",
+			Id:   123,
+			Environments: NewRemoteLazyLoader[*GithubEnvironment](func() map[string]*GithubEnvironment {
+				envs := make(map[string]*GithubEnvironment)
+				envs["production"] = &GithubEnvironment{
+					Name:      "production",
+					Variables: map[string]string{},
+				}
+				return envs
+			}),
+		}
+		remoteImpl.repositories = map[string]*GithubRepository{
+			"test-repo": repo,
+		}
+
+		// Try to delete non-existent variable
+		remoteImpl.DeleteRepositoryEnvironmentVariable(ctx, errorCollector, false, "test-repo", "production", "TEST_VAR")
+
+		// Verify error was collected
+		assert.NotEmpty(t, errorCollector.Errors)
+		assert.Contains(t, errorCollector.Errors[0].Error(), "variable TEST_VAR not found")
+
+		// Verify no API calls were made
+		assert.Equal(t, 2, mockClient.callCount) // Only getGHESVersion
+	})
+
+	t.Run("happy path: dry run mode", func(t *testing.T) {
+		mockClient := &LoadEnvironmentVariablesMockClient{}
+
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true)
+		ctx := context.TODO()
+		errorCollector := observability.NewErrorCollection()
+
+		// Create a repository with an environment and existing variable
+		repo := &GithubRepository{
+			Name: "test-repo",
+			Id:   123,
+			Environments: NewRemoteLazyLoader[*GithubEnvironment](func() map[string]*GithubEnvironment {
+				envs := make(map[string]*GithubEnvironment)
+				envs["production"] = &GithubEnvironment{
+					Name: "production",
+					Variables: map[string]string{
+						"TEST_VAR": "value",
+					},
+				}
+				return envs
+			}),
+		}
+		remoteImpl.repositories = map[string]*GithubRepository{
+			"test-repo": repo,
+		}
+
+		// Delete variable in dry run mode
+		remoteImpl.DeleteRepositoryEnvironmentVariable(ctx, errorCollector, true, "test-repo", "production", "TEST_VAR")
+
+		// Verify no errors occurred
+		assert.Empty(t, errorCollector.Errors)
+
+		// Verify no API calls were made
+		assert.Equal(t, 2, mockClient.callCount) // Only getGHESVersion
+
+		// Verify variable was removed from repository environment
+		envs := repo.Environments.GetEntity()
+		assert.NotNil(t, envs)
+		assert.Equal(t, 1, len(envs))
+		assert.NotNil(t, envs["production"])
+		assert.Empty(t, envs["production"].Variables)
+	})
+
+	t.Run("error path: API error", func(t *testing.T) {
+		mockClient := &LoadEnvironmentVariablesMockClient{
+			shouldError:  true,
+			errorMessage: "API error",
+		}
+
+		remoteImpl := NewGoliacRemoteImpl(mockClient, "myorg", true)
+		ctx := context.TODO()
+		errorCollector := observability.NewErrorCollection()
+
+		// Create a repository with an environment and existing variable
+		repo := &GithubRepository{
+			Name: "test-repo",
+			Id:   123,
+			Environments: NewRemoteLazyLoader[*GithubEnvironment](func() map[string]*GithubEnvironment {
+				envs := make(map[string]*GithubEnvironment)
+				envs["production"] = &GithubEnvironment{
+					Name: "production",
+					Variables: map[string]string{
+						"TEST_VAR": "value",
+					},
+				}
+				return envs
+			}),
+		}
+		remoteImpl.repositories = map[string]*GithubRepository{
+			"test-repo": repo,
+		}
+
+		// Try to delete variable
+		remoteImpl.DeleteRepositoryEnvironmentVariable(ctx, errorCollector, false, "test-repo", "production", "TEST_VAR")
+
+		// Verify error was collected
+		assert.NotEmpty(t, errorCollector.Errors)
+		assert.Contains(t, errorCollector.Errors[0].Error(), "API error")
+
+		// Verify API call was made
+		assert.Equal(t, 3, mockClient.callCount) // 1 for getGHESVersion, 1 for deleting variable
+		assert.Equal(t, "/repos/myorg/test-repo/environments/production/variables/TEST_VAR", mockClient.lastEndpoint)
+		assert.Equal(t, "", mockClient.lastParameters)
+		assert.Equal(t, "DELETE", mockClient.lastMethod)
+		assert.Nil(t, mockClient.lastBody)
+
+		// Verify variable was not removed from repository environment
+		envs := repo.Environments.GetEntity()
+		assert.NotNil(t, envs)
+		assert.Equal(t, 1, len(envs))
+		assert.NotNil(t, envs["production"])
+		assert.Equal(t, "value", envs["production"].Variables["TEST_VAR"])
 	})
 }

--- a/internal/goliac.go
+++ b/internal/goliac.go
@@ -126,7 +126,7 @@ func (g *GoliacImpl) SetRemoteObservability(feedback observability.RemoteObserva
 	g.remote.SetRemoteObservability(feedback)
 
 	if feedback != nil {
-		nb, err := g.remote.CountAssets(context.Background())
+		nb, err := g.remote.CountAssets(context.Background(), false)
 		if err != nil {
 			return fmt.Errorf("error when counting assets: %v", err)
 		}

--- a/internal/goliac_test.go
+++ b/internal/goliac_test.go
@@ -557,7 +557,7 @@ func (e *GoliacRemoteExecutorMock) AppIds(ctx context.Context) map[string]int {
 func (e *GoliacRemoteExecutorMock) IsEnterprise() bool {
 	return true
 }
-func (m *GoliacRemoteExecutorMock) CountAssets(ctx context.Context) (int, error) {
+func (m *GoliacRemoteExecutorMock) CountAssets(ctx context.Context, warmup bool) (int, error) {
 	return 4, nil
 }
 func (g *GoliacRemoteExecutorMock) SetRemoteObservability(feedback observability.RemoteObservability) {

--- a/internal/scaffold.go
+++ b/internal/scaffold.go
@@ -389,9 +389,9 @@ func (s *Scaffold) generateTeams(ctx context.Context, fs billy.Filesystem, teams
 					// scaffoldling repository environments, env variables and variables
 					rEnvironments := rRepo.Environments
 					if rEnvironments != nil {
-						lRepo.Spec.Environments = make([]entity.RepositoryEnvironment, 0, len(rEnvironments))
+						lRepo.Spec.Environments = make([]entity.RepositoryEnvironment, 0, len(rEnvironments.GetEntity()))
 
-						for _, e := range rEnvironments {
+						for _, e := range rEnvironments.GetEntity() {
 							re := entity.RepositoryEnvironment{
 								Name:      e.Name,
 								Variables: make(map[string]string),
@@ -404,8 +404,10 @@ func (s *Scaffold) generateTeams(ctx context.Context, fs billy.Filesystem, teams
 					}
 
 					lRepo.Spec.ActionsVariables = make(map[string]string)
-					for n, v := range rRepo.RepositoryVariables {
-						lRepo.Spec.ActionsVariables[n] = v
+					if rRepo.RepositoryVariables != nil {
+						for n, v := range rRepo.RepositoryVariables.GetEntity() {
+							lRepo.Spec.ActionsVariables[n] = v
+						}
 					}
 				}
 

--- a/internal/scaffold.go
+++ b/internal/scaffold.go
@@ -61,7 +61,7 @@ func (s *Scaffold) SetRemoteObservability(feedback observability.RemoteObservabi
 	s.remote.SetRemoteObservability(feedback)
 	s.feedback = feedback
 	if feedback != nil {
-		nb, err := s.remote.CountAssets(context.Background())
+		nb, err := s.remote.CountAssets(context.Background(), true)
 		if err != nil {
 			return fmt.Errorf("error when counting assets: %v", err)
 		}
@@ -224,6 +224,41 @@ func (s *Scaffold) generateTeams(ctx context.Context, fs billy.Filesystem, teams
 			}
 		}
 	}
+
+	// warmup
+	repos := s.remote.Repositories(ctx)
+	jobs := make(chan *engine.GithubRepository, len(repos))
+	results := make(chan error, len(repos))
+
+	// Start workers
+	for w := int64(0); w < config.Config.GithubConcurrentThreads; w++ {
+		go func() {
+			for r := range jobs {
+				r.Environments.GetEntity()
+				if s.feedback != nil {
+					s.feedback.LoadingAsset(fmt.Sprintf("environments for %s", r.Name), 1)
+				}
+				r.RepositoryVariables.GetEntity()
+				if s.feedback != nil {
+					s.feedback.LoadingAsset(fmt.Sprintf("variables for %s", r.Name), 1)
+				}
+				results <- nil
+			}
+		}()
+	}
+
+	// Send jobs
+	for _, r := range repos {
+		jobs <- r
+	}
+	close(jobs)
+
+	// Wait for all jobs to complete
+	for i := 0; i < len(repos); i++ {
+		<-results
+	}
+
+	// end of warmup
 
 	countOrphaned := 0
 	// orphan repos should go to the admin team

--- a/internal/scaffold_test.go
+++ b/internal/scaffold_test.go
@@ -334,6 +334,18 @@ func TestScaffoldUnit(t *testing.T) {
 	})
 }
 
+type MockMappedEntityLazyLoader[T any] struct {
+	entity map[string]T
+}
+
+func (m *MockMappedEntityLazyLoader[T]) GetEntity() map[string]T {
+	return m.entity
+}
+
+func NewMockMappedEntityLazyLoader[T any](entity map[string]T) *MockMappedEntityLazyLoader[T] {
+	return &MockMappedEntityLazyLoader[T]{entity: entity}
+}
+
 func TestEnvironmentsAndVariables(t *testing.T) {
 	t.Run("happy path: test environments and variables", func(t *testing.T) {
 
@@ -371,23 +383,23 @@ func TestEnvironmentsAndVariables(t *testing.T) {
 		repo2 := engine.GithubRepository{
 			Name: "repo2",
 		}
-		repo2.Environments = map[string]*engine.GithubEnvironment{
+		repo2.Environments = NewMockMappedEntityLazyLoader[*engine.GithubEnvironment](map[string]*engine.GithubEnvironment{
 			"env1": {
 				Name: "env1",
 			},
 			"env2": {
 				Name: "env2",
 			},
-		}
-		repo2.Environments["env1"].Variables = map[string]string{
+		})
+		repo2.Environments.GetEntity()["env1"].Variables = map[string]string{
 			"var1": "value1",
 		}
-		repo2.Environments["env2"].Variables = map[string]string{
+		repo2.Environments.GetEntity()["env2"].Variables = map[string]string{
 			"var2": "value2",
 		}
-		repo2.RepositoryVariables = map[string]string{
+		repo2.RepositoryVariables = NewMockMappedEntityLazyLoader[string](map[string]string{
 			"var2": "value2",
-		}
+		})
 
 		repos["repo2"] = &repo2
 

--- a/internal/scaffold_test.go
+++ b/internal/scaffold_test.go
@@ -57,7 +57,7 @@ func (s *ScaffoldGoliacRemoteMock) AppIds(ctx context.Context) map[string]int {
 func (s *ScaffoldGoliacRemoteMock) IsEnterprise() bool {
 	return true
 }
-func (m *ScaffoldGoliacRemoteMock) CountAssets(ctx context.Context) (int, error) {
+func (m *ScaffoldGoliacRemoteMock) CountAssets(ctx context.Context, warmup bool) (int, error) {
 	return 2*len(m.repos) + len(m.teams) + len(m.users), nil
 }
 func (g *ScaffoldGoliacRemoteMock) SetRemoteObservability(feedback observability.RemoteObservability) {
@@ -99,18 +99,24 @@ func NewScaffoldGoliacRemoteMock() engine.GoliacRemote {
 	teams["regular"] = &regular
 
 	repo1 := engine.GithubRepository{
-		Name: "repo1",
+		Name:                "repo1",
+		Environments:        NewMockMappedEntityLazyLoader(map[string]*engine.GithubEnvironment{}),
+		RepositoryVariables: NewMockMappedEntityLazyLoader[string](map[string]string{}),
 	}
 	repos["repo1"] = &repo1
 
 	repo2 := engine.GithubRepository{
-		Name: "repo2",
+		Name:                "repo2",
+		Environments:        NewMockMappedEntityLazyLoader(map[string]*engine.GithubEnvironment{}),
+		RepositoryVariables: NewMockMappedEntityLazyLoader[string](map[string]string{}),
 	}
 	repos["repo2"] = &repo2
 
 	archivedRepo := engine.GithubRepository{
-		Name:           "archived_repo",
-		BoolProperties: map[string]bool{"archived": true},
+		Name:                "archived_repo",
+		Environments:        NewMockMappedEntityLazyLoader(map[string]*engine.GithubEnvironment{}),
+		RepositoryVariables: NewMockMappedEntityLazyLoader[string](map[string]string{}),
+		BoolProperties:      map[string]bool{"archived": true},
 	}
 	repos["archived_repo"] = &archivedRepo
 
@@ -174,12 +180,16 @@ func NewScaffoldGoliacRemoteMockWithMaintainers() engine.GoliacRemote {
 	teams["regular"] = &regular
 
 	repo1 := engine.GithubRepository{
-		Name: "repo1",
+		Name:                "repo1",
+		Environments:        NewMockMappedEntityLazyLoader(map[string]*engine.GithubEnvironment{}),
+		RepositoryVariables: NewMockMappedEntityLazyLoader[string](map[string]string{}),
 	}
 	repos["repo1"] = &repo1
 
 	repo2 := engine.GithubRepository{
-		Name: "repo2",
+		Name:                "repo2",
+		Environments:        NewMockMappedEntityLazyLoader(map[string]*engine.GithubEnvironment{}),
+		RepositoryVariables: NewMockMappedEntityLazyLoader[string](map[string]string{}),
 	}
 	repos["repo2"] = &repo2
 
@@ -376,7 +386,9 @@ func TestEnvironmentsAndVariables(t *testing.T) {
 		teams["regular"] = &regular
 
 		repo1 := engine.GithubRepository{
-			Name: "repo1",
+			Name:                "repo1",
+			Environments:        NewMockMappedEntityLazyLoader(map[string]*engine.GithubEnvironment{}),
+			RepositoryVariables: NewMockMappedEntityLazyLoader[string](map[string]string{}),
 		}
 		repos["repo1"] = &repo1
 


### PR DESCRIPTION
instead of trying to load environment and variables for all repositories upfront, use a lazy loading way:
- when reconcilliating, we will effectively call Github API to load the values
- except for archived repositories that we dont care much (for environments and variables)

to do so, let's introduce the generic entity_lazy_loader.go file

One side effect: the loading of (environment) assets is not done in parallel