### PR TITLE
feat: support for repository Custom Properties

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -154,6 +154,22 @@ usersync:
 #  forbid_public_repositories_exclusions: # if you want to allow some public repositories
 #    - goliac-teams
 #    - repo_public.*
+
+#org_custom_properties: # organization-level custom properties schema definitions
+#  - property_name: environment
+#    value_type: single_select # can be "string", "single_select", or "multi_select"
+#    required: true
+#    default_value: production
+#    description: Production or development environment
+#    allowed_values: # required for single_select and multi_select
+#      - production
+#      - development
+#      - staging
+#    values_editable_by: org_actors # can be "org_actors" or "org_and_repo_actors"
+#  - property_name: tier
+#    value_type: string
+#    required: false
+#    description: Service tier classification
 ```
 
 and you can configure different ruleset in the `/rulesets` directory like

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -33,6 +33,7 @@ In GitHub:
 - Under Repository permissions
   - Give Read/Write access to `Administration`
   - Give Read/Write access to `Content` (it is needed to access the default branch of repositories)
+  - Give Read/Write access to `Custom properties` (it is needed to manage custom properties of repositories)
 - Under Subscribe to events
   - (optional)Select `Push` (if you want to be notified immedately of changes on the goliac teams repository. else it will be polled every 10 minutes)
   - Select `Issue comments` (needed for the Breaking glass workflow)

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -42,6 +42,7 @@ As a Github org admin, in GitHub:
 - Under Repository permissions
   - Give Read/Write access to `Administration`
   - Give Read/Write access to `Content`
+  - Give Read/Write access to `Custom properties`
 - Where can this GitHub App be installed: `Only on this account`
 - And Create
 - then you must
@@ -192,7 +193,7 @@ where:
 
 ### 4. Verify
 
-Eventually you can check the structure of your configuration, by running 
+Eventually you can check the structure of your configuration, by running
 
 ```shell
 goliac verify <goliac-team directory>

--- a/docs/resource_repository.md
+++ b/docs/resource_repository.md
@@ -40,6 +40,11 @@ spec:
   readers:
   - anotherteamC
   - anotherteamD
+  custom_properties:
+    Foo: 'bar'
+    Baz:
+      - qux
+      - quux
 ```
 
 In this last example:
@@ -117,7 +122,7 @@ spec:
     - name: myruleset
       enforcement: active # disabled, active, evaluate
       conditions:
-        include: 
+        include:
           - "~DEFAULT_BRANCH" # ~DEFAULT_BRANCH, ~ALL, branch_name, ...
       rules:
         - ruletype: required_signatures
@@ -136,7 +141,7 @@ spec:
     - name: myruleset
       enforcement: active # disabled, active, evaluate
       conditions:
-        include: 
+        include:
           - develop
       rules:
         - ruletype: pull_request
@@ -159,7 +164,7 @@ spec:
     - name: myruleset
       enforcement: active # disabled, active, evaluate
       conditions:
-        include: 
+        include:
           - "~ALL"
       rules:
         - ruletype: required_status_checks
@@ -265,7 +270,7 @@ gh secret set SECRET1 --env staging --repo <my organization>/<repository> --body
 ## Add external users to a repository
 
 If you want to give access (read or write) to users external to your organization, you need to
-- add a definition of the user in the `/users/external` directory 
+- add a definition of the user in the `/users/external` directory
 - add them to the repository
 
 To add them to the repository you can use the `externalUserReaders` and `externalUserWriters` properties, like
@@ -319,3 +324,18 @@ name: awesome-repository
 spec:
   autolinks: []
 ```
+
+## Custom properties
+
+You can set custom properties in the repository definition. Custom properties can be strings or arrays of strings.
+
+```yaml
+apiVersion: v1
+kind: Repository
+name: awesome-repository
+spec:
+  custom_properties:
+    Foo: 'bar'
+    Baz:
+      - qux
+      - quux

--- a/internal/config/repo_config.go
+++ b/internal/config/repo_config.go
@@ -38,8 +38,8 @@ type RepositoryConfig struct {
 		ForbidPublicRepositoriesExclusions []string `yaml:"forbid_public_repositories_exclusions"`
 	} `yaml:"visibility_rules"`
 
-	Workflows           []string               `yaml:"workflows"`
-	OrgCustomProperties []GithubCustomProperty `yaml:"org_custom_properties"`
+	Workflows           []string                `yaml:"workflows"`
+	OrgCustomProperties []*GithubCustomProperty `yaml:"org_custom_properties"`
 }
 
 // set default values
@@ -56,6 +56,14 @@ func (rc *RepositoryConfig) UnmarshalYAML(value *yaml.Node) error {
 		return err
 	}
 
+	// add org_actors systematically to the org_custom_properties
+	for _, orgProperty := range x.OrgCustomProperties {
+		if orgProperty.ValuesEditableBy == "" {
+			orgProperty.ValuesEditableBy = "org_actors"
+		}
+	}
+
 	*rc = RepositoryConfig(*x)
+
 	return nil
 }

--- a/internal/config/repo_config.go
+++ b/internal/config/repo_config.go
@@ -4,6 +4,16 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+type GithubCustomProperty struct {
+	PropertyName     string   `yaml:"property_name" json:"property_name"`
+	ValueType        string   `yaml:"value_type" json:"value_type"` // "string", "single_select", "multi_select"
+	Required         bool     `yaml:"required,omitempty" json:"required,omitempty"`
+	DefaultValue     string   `yaml:"default_value,omitempty" json:"default_value,omitempty"`
+	Description      string   `yaml:"description,omitempty" json:"description,omitempty"`
+	AllowedValues    []string `yaml:"allowed_values,omitempty" json:"allowed_values,omitempty"`
+	ValuesEditableBy string   `yaml:"values_editable_by,omitempty" json:"values_editable_by,omitempty"` // "org_actors", "org_and_repo_actors"
+}
+
 type RepositoryConfig struct {
 	AdminTeam           string `yaml:"admin_team"`
 	EveryoneTeamEnabled bool   `yaml:"everyone_team_enabled"`
@@ -28,7 +38,8 @@ type RepositoryConfig struct {
 		ForbidPublicRepositoriesExclusions []string `yaml:"forbid_public_repositories_exclusions"`
 	} `yaml:"visibility_rules"`
 
-	Workflows []string `yaml:"workflows"`
+	Workflows           []string               `yaml:"workflows"`
+	OrgCustomProperties []GithubCustomProperty `yaml:"org_custom_properties"`
 }
 
 // set default values

--- a/internal/engine/entity_comparision.go
+++ b/internal/engine/entity_comparision.go
@@ -1,7 +1,9 @@
 package engine
 
+import "github.com/goliac-project/goliac/internal/config"
+
 type Comparable interface {
-	*GithubTeamComparable | *GithubRepoComparable | *GithubRuleSet | *GithubBranchProtection | *GithubEnvironment | *GithubAutolink
+	*GithubTeamComparable | *GithubRepoComparable | *GithubRuleSet | *GithubBranchProtection | *GithubEnvironment | *GithubAutolink | *config.GithubCustomProperty
 }
 
 type CompareEqualAB[A Comparable, B Comparable] func(key string, value1 A, value2 B) bool

--- a/internal/engine/goliac_reconciliator.go
+++ b/internal/engine/goliac_reconciliator.go
@@ -578,12 +578,6 @@ func (r *GoliacReconciliatorImpl) reconciliateRepositories(
 							"old_value":  remoteStr,
 							"new_value":  localStr,
 						}, "Updating custom property %s for repository %s: %s -> %s", propName, reponame, remoteStr, localStr)
-					} else {
-						logsCollector.AddInfo(map[string]any{
-							"repository": reponame,
-							"property":   propName,
-							"new_value":  localStr,
-						}, "Setting custom property %s for repository %s: %s", propName, reponame, localStr)
 					}
 					r.UpdateRepositoryCustomProperties(ctx, logsCollector, dryrun, remote, reponame, propName, localValue)
 				}

--- a/internal/engine/goliac_reconciliator_datasource.go
+++ b/internal/engine/goliac_reconciliator_datasource.go
@@ -15,6 +15,7 @@ type GoliacReconciliatorDatasource interface {
 	Teams() (map[string]*GithubTeamComparable, map[string]bool, error)          // team, externallyManaged, error
 	Repositories() (map[string]*GithubRepoComparable, map[string]string, error) // repo, renameTo, error
 	RuleSets() (map[string]*GithubRuleSet, error)
+	OrgCustomProperties(ctx context.Context) map[string]*config.GithubCustomProperty
 }
 
 type GoliacReconciliatorDatasourceLocal struct {
@@ -402,6 +403,15 @@ func (d *GoliacReconciliatorDatasourceLocal) RuleSets() (map[string]*GithubRuleS
 	return lgrs, nil
 }
 
+func (d *GoliacReconciliatorDatasourceLocal) OrgCustomProperties(ctx context.Context) map[string]*config.GithubCustomProperty {
+	localProps := make(map[string]*config.GithubCustomProperty)
+	for _, prop := range d.conf.OrgCustomProperties {
+		propCopy := prop
+		localProps[prop.PropertyName] = propCopy
+	}
+	return localProps
+}
+
 type GoliacReconciliatorDatasourceRemote struct {
 	remote GoliacRemote
 }
@@ -539,4 +549,8 @@ func (d *GoliacReconciliatorDatasourceRemote) Repositories() (map[string]*Github
 
 func (d *GoliacReconciliatorDatasourceRemote) RuleSets() (map[string]*GithubRuleSet, error) {
 	return d.remote.RuleSets(context.Background()), nil
+}
+
+func (d *GoliacReconciliatorDatasourceRemote) OrgCustomProperties(ctx context.Context) map[string]*config.GithubCustomProperty {
+	return d.remote.OrgCustomProperties(ctx)
 }

--- a/internal/engine/goliac_reconciliator_test.go
+++ b/internal/engine/goliac_reconciliator_test.go
@@ -288,6 +288,9 @@ func (r *ReconciliatorListenerRecorder) RenameRepository(ctx context.Context, lo
 func (r *ReconciliatorListenerRecorder) UpdateRepositoryUpdateProperties(ctx context.Context, logsCollector *observability.LogCollection, dryrun bool, reponame string, properties map[string]interface{}) {
 	r.RepositoriesUpdateProperty[reponame] = true
 }
+func (r *ReconciliatorListenerRecorder) UpdateRepositoryCustomProperties(ctx context.Context, logsCollector *observability.LogCollection, dryrun bool, reponame string, propertyName string, propertyValue interface{}) {
+	// Track custom property updates if needed for testing
+}
 func (r *ReconciliatorListenerRecorder) UpdateRepositorySetExternalUser(ctx context.Context, logsCollector *observability.LogCollection, dryrun bool, reponame string, githubid string, permission string) {
 	r.RepositoriesSetExternalUser[githubid] = permission
 }

--- a/internal/engine/goliac_reconciliator_test.go
+++ b/internal/engine/goliac_reconciliator_test.go
@@ -141,6 +141,9 @@ func (m *GoliacRemoteMock) RepositoriesSecretsPerRepository(ctx context.Context,
 func (m *GoliacRemoteMock) EnvironmentSecretsPerRepository(ctx context.Context, environments []string, repositoryName string) (map[string]map[string]*GithubVariable, error) {
 	return nil, nil
 }
+func (m *GoliacRemoteMock) OrgCustomProperties(ctx context.Context) map[string]*config.GithubCustomProperty {
+	return make(map[string]*config.GithubCustomProperty)
+}
 
 type MockMappedEntityLazyLoader[T any] struct {
 	entity map[string]T

--- a/internal/engine/mutable_remote.go
+++ b/internal/engine/mutable_remote.go
@@ -409,6 +409,16 @@ func (m *MutableGoliacRemoteImpl) UpdateRepositoryUpdateProperties(reponame stri
 		}
 	}
 }
+
+func (m *MutableGoliacRemoteImpl) UpdateRepositoryCustomProperties(reponame string, propertyName string, propertyValue interface{}) {
+	if r, ok := m.repositories[reponame]; ok {
+		if r.CustomProperties == nil {
+			r.CustomProperties = make(map[string]interface{})
+		}
+		r.CustomProperties[propertyName] = propertyValue
+	}
+}
+
 func (m *MutableGoliacRemoteImpl) UpdateRepositorySetExternalUser(reponame string, collaboatorGithubId string, permission string) {
 	if r, ok := m.repositories[reponame]; ok {
 		if permission == "pull" {

--- a/internal/engine/mutable_remote.go
+++ b/internal/engine/mutable_remote.go
@@ -3,6 +3,7 @@ package engine
 import (
 	"context"
 
+	"github.com/goliac-project/goliac/internal/config"
 	"github.com/goliac-project/goliac/internal/entity"
 	"github.com/gosimple/slug"
 )
@@ -71,10 +72,11 @@ It is by design
 - and a kind of ReconciliatorExecutor (as a ReconciliatorExecutor writer)
 */
 type MutableGoliacRemoteImpl struct {
-	users        map[string]string
-	repositories map[string]*GithubRepoComparable
-	teams        map[string]*GithubTeamComparable
-	rulesets     map[string]*GithubRuleSet
+	users               map[string]string
+	repositories        map[string]*GithubRepoComparable
+	teams               map[string]*GithubTeamComparable
+	rulesets            map[string]*GithubRuleSet
+	orgCustomProperties map[string]*config.GithubCustomProperty
 }
 
 func NewMutableGoliacRemoteImpl(ctx context.Context, remote GoliacReconciliatorDatasource) (*MutableGoliacRemoteImpl, error) {
@@ -163,11 +165,22 @@ func NewMutableGoliacRemoteImpl(ctx context.Context, remote GoliacReconciliatorD
 		rrulesets[k] = &ghRuleset
 	}
 
+	// Get org custom properties from remote if it implements GoliacRemote
+	rorgCustomProperties := make(map[string]*config.GithubCustomProperty)
+	orgProps := remote.OrgCustomProperties(ctx)
+	for k, v := range orgProps {
+		if v != nil {
+			propCopy := *v
+			rorgCustomProperties[k] = &propCopy
+		}
+	}
+
 	return &MutableGoliacRemoteImpl{
-		users:        rUsers,
-		repositories: rRepositories,
-		teams:        rTeams,
-		rulesets:     rrulesets,
+		users:               rUsers,
+		repositories:        rRepositories,
+		teams:               rTeams,
+		rulesets:            rrulesets,
+		orgCustomProperties: rorgCustomProperties,
 	}, nil
 }
 
@@ -184,6 +197,10 @@ func (m *MutableGoliacRemoteImpl) Repositories() map[string]*GithubRepoComparabl
 }
 func (m *MutableGoliacRemoteImpl) RuleSets() map[string]*GithubRuleSet {
 	return m.rulesets
+}
+
+func (m *MutableGoliacRemoteImpl) OrgCustomProperties() map[string]*config.GithubCustomProperty {
+	return m.orgCustomProperties
 }
 
 // LISTENER
@@ -487,6 +504,20 @@ func (m *MutableGoliacRemoteImpl) DeleteRuleset(rulesetid int) {
 			delete(m.rulesets, rs.Name)
 			break
 		}
+	}
+}
+
+func (m *MutableGoliacRemoteImpl) CreateOrUpdateOrgCustomProperty(property *config.GithubCustomProperty) {
+	if m.orgCustomProperties == nil {
+		m.orgCustomProperties = make(map[string]*config.GithubCustomProperty)
+	}
+	propCopy := *property
+	m.orgCustomProperties[property.PropertyName] = &propCopy
+}
+
+func (m *MutableGoliacRemoteImpl) DeleteOrgCustomProperty(propertyName string) {
+	if m.orgCustomProperties != nil {
+		delete(m.orgCustomProperties, propertyName)
 	}
 }
 

--- a/internal/engine/reconciliator_executor.go
+++ b/internal/engine/reconciliator_executor.go
@@ -3,6 +3,7 @@ package engine
 import (
 	"context"
 
+	"github.com/goliac-project/goliac/internal/config"
 	"github.com/goliac-project/goliac/internal/observability"
 )
 
@@ -57,6 +58,10 @@ type ReconciliatorExecutor interface {
 	AddRepositoryAutolink(ctx context.Context, logsCollector *observability.LogCollection, dryrun bool, repositoryName string, autolink *GithubAutolink)
 	DeleteRepositoryAutolink(ctx context.Context, logsCollector *observability.LogCollection, dryrun bool, repositoryName string, autolinkId int)
 	UpdateRepositoryAutolink(ctx context.Context, logsCollector *observability.LogCollection, dryrun bool, repositoryName string, previousAutolinkId int, autolink *GithubAutolink)
+
+	// Organization custom properties management
+	CreateOrUpdateOrgCustomProperty(ctx context.Context, logsCollector *observability.LogCollection, dryrun bool, property *config.GithubCustomProperty)
+	DeleteOrgCustomProperty(ctx context.Context, logsCollector *observability.LogCollection, dryrun bool, propertyName string)
 
 	Begin(logsCollector *observability.LogCollection, dryrun bool)
 	Rollback(logsCollector *observability.LogCollection, dryrun bool, err error)

--- a/internal/engine/reconciliator_executor.go
+++ b/internal/engine/reconciliator_executor.go
@@ -20,6 +20,7 @@ type ReconciliatorExecutor interface {
 	// CreateRepository can have a githubToken parameter (if null it use Goliac token)
 	CreateRepository(ctx context.Context, logsCollector *observability.LogCollection, dryrun bool, reponame string, descrition string, visibility string, writers []string, readers []string, boolProperties map[string]bool, defaultBranch string, githubToken *string, forkFrom string)
 	UpdateRepositoryUpdateProperties(ctx context.Context, logsCollector *observability.LogCollection, dryrun bool, reponame string, properties map[string]interface{})
+	UpdateRepositoryCustomProperties(ctx context.Context, logsCollector *observability.LogCollection, dryrun bool, reponame string, propertyName string, propertyValue interface{})
 	UpdateRepositoryAddTeamAccess(ctx context.Context, logsCollector *observability.LogCollection, dryrun bool, reponame string, teamslug string, permission string)    // permission can be "pull", "push", or "admin" which correspond to read, write, and admin access.
 	UpdateRepositoryUpdateTeamAccess(ctx context.Context, logsCollector *observability.LogCollection, dryrun bool, reponame string, teamslug string, permission string) // permission can be "pull", "push", or "admin" which correspond to read, write, and admin access.
 	UpdateRepositoryRemoveTeamAccess(ctx context.Context, logsCollector *observability.LogCollection, dryrun bool, reponame string, teamslug string)

--- a/internal/engine/remote.go
+++ b/internal/engine/remote.go
@@ -1685,6 +1685,13 @@ func (g *GoliacRemoteImpl) CreateOrUpdateOrgCustomProperty(ctx context.Context, 
 			return
 		}
 	}
+
+	g.actionMutex.Lock()
+	defer g.actionMutex.Unlock()
+
+	// Update local cache
+	propCopy := *property
+	g.orgCustomProperties[property.PropertyName] = &propCopy
 }
 
 func (g *GoliacRemoteImpl) DeleteOrgCustomProperty(ctx context.Context, logsCollector *observability.LogCollection, dryrun bool, propertyName string) {
@@ -1703,6 +1710,12 @@ func (g *GoliacRemoteImpl) DeleteOrgCustomProperty(ctx context.Context, logsColl
 			return
 		}
 	}
+
+	g.actionMutex.Lock()
+	defer g.actionMutex.Unlock()
+
+	// Update local cache
+	delete(g.orgCustomProperties, propertyName)
 }
 
 // func (g *GoliacRemoteImpl) loadEnvironmentVariables(ctx context.Context, maxGoroutines int64, repositories map[string]*GithubRepository) (map[string]map[string]map[string]*GithubVariable, error) {

--- a/internal/github_batch_executor.go
+++ b/internal/github_batch_executor.go
@@ -410,6 +410,22 @@ func (g *GithubBatchExecutor) UpdateRepositoryAutolink(ctx context.Context, logs
 	})
 }
 
+func (g *GithubBatchExecutor) CreateOrUpdateOrgCustomProperty(ctx context.Context, logsCollector *observability.LogCollection, dryrun bool, property *config.GithubCustomProperty) {
+	g.commands = append(g.commands, &GithubCommandCreateOrUpdateOrgCustomProperty{
+		client:   g.client,
+		dryrun:   dryrun,
+		property: property,
+	})
+}
+
+func (g *GithubBatchExecutor) DeleteOrgCustomProperty(ctx context.Context, logsCollector *observability.LogCollection, dryrun bool, propertyName string) {
+	g.commands = append(g.commands, &GithubCommandDeleteOrgCustomProperty{
+		client:       g.client,
+		dryrun:       dryrun,
+		propertyName: propertyName,
+	})
+}
+
 func (g *GithubBatchExecutor) Begin(logsCollector *observability.LogCollection, dryrun bool) {
 	g.commands = make([]GithubCommand, 0)
 }
@@ -870,4 +886,24 @@ type GithubCommandUpdateRepositoryAutolink struct {
 
 func (g *GithubCommandUpdateRepositoryAutolink) Apply(ctx context.Context, logsCollector *observability.LogCollection) {
 	g.client.UpdateRepositoryAutolink(ctx, logsCollector, g.dryrun, g.reponame, g.previousAutolinkId, g.autolink)
+}
+
+type GithubCommandCreateOrUpdateOrgCustomProperty struct {
+	client   engine.ReconciliatorExecutor
+	dryrun   bool
+	property *config.GithubCustomProperty
+}
+
+func (g *GithubCommandCreateOrUpdateOrgCustomProperty) Apply(ctx context.Context, logsCollector *observability.LogCollection) {
+	g.client.CreateOrUpdateOrgCustomProperty(ctx, logsCollector, g.dryrun, g.property)
+}
+
+type GithubCommandDeleteOrgCustomProperty struct {
+	client       engine.ReconciliatorExecutor
+	dryrun       bool
+	propertyName string
+}
+
+func (g *GithubCommandDeleteOrgCustomProperty) Apply(ctx context.Context, logsCollector *observability.LogCollection) {
+	g.client.DeleteOrgCustomProperty(ctx, logsCollector, g.dryrun, g.propertyName)
 }

--- a/internal/github_batch_executor.go
+++ b/internal/github_batch_executor.go
@@ -172,6 +172,16 @@ func (g *GithubBatchExecutor) UpdateRepositoryUpdateProperties(ctx context.Conte
 	})
 }
 
+func (g *GithubBatchExecutor) UpdateRepositoryCustomProperties(ctx context.Context, logsCollector *observability.LogCollection, dryrun bool, reponame string, propertyName string, propertyValue interface{}) {
+	g.commands = append(g.commands, &GithubCommandUpdateRepositoryCustomProperties{
+		client:        g.client,
+		dryrun:        dryrun,
+		reponame:      reponame,
+		propertyName:  propertyName,
+		propertyValue: propertyValue,
+	})
+}
+
 func (g *GithubBatchExecutor) UpdateRepositorySetExternalUser(ctx context.Context, logsCollector *observability.LogCollection, dryrun bool, reponame string, githubid string, permission string) {
 	g.commands = append(g.commands, &GithubCommandUpdateRepositorySetExternalUser{
 		client:     g.client,
@@ -577,6 +587,18 @@ type GithubCommandUpdateRepositoryUpdateProperties struct {
 
 func (g *GithubCommandUpdateRepositoryUpdateProperties) Apply(ctx context.Context, logsCollector *observability.LogCollection) {
 	g.client.UpdateRepositoryUpdateProperties(ctx, logsCollector, g.dryrun, g.reponame, g.properties)
+}
+
+type GithubCommandUpdateRepositoryCustomProperties struct {
+	client        engine.ReconciliatorExecutor
+	dryrun        bool
+	reponame      string
+	propertyName  string
+	propertyValue interface{}
+}
+
+func (g *GithubCommandUpdateRepositoryCustomProperties) Apply(ctx context.Context, logsCollector *observability.LogCollection) {
+	g.client.UpdateRepositoryCustomProperties(ctx, logsCollector, g.dryrun, g.reponame, g.propertyName, g.propertyValue)
 }
 
 type GithubCommandUpdateTeamAddMember struct {

--- a/internal/goliac_test.go
+++ b/internal/goliac_test.go
@@ -130,7 +130,7 @@ spec:
       - appname: goliac-project-app
         mode: always
     conditions:
-      include: 
+      include:
         - "~DEFAULT_BRANCH"
 
     rules:
@@ -635,6 +635,10 @@ func (e *GoliacRemoteExecutorMock) CreateRepository(ctx context.Context, logsCol
 }
 func (e *GoliacRemoteExecutorMock) UpdateRepositoryUpdateProperties(ctx context.Context, logsCollector *observability.LogCollection, dryrun bool, reponame string, properties map[string]interface{}) {
 	fmt.Println("*** UpdateRepositoryUpdateProperties", reponame, properties)
+	e.nbChanges++
+}
+func (e *GoliacRemoteExecutorMock) UpdateRepositoryCustomProperties(ctx context.Context, logsCollector *observability.LogCollection, dryrun bool, reponame string, propertyName string, propertyValue interface{}) {
+	fmt.Println("*** UpdateRepositoryCustomProperties", reponame, propertyName, propertyValue)
 	e.nbChanges++
 }
 func (e *GoliacRemoteExecutorMock) UpdateRepositoryAddTeamAccess(ctx context.Context, logsCollector *observability.LogCollection, dryrun bool, reponame string, teamslug string, permission string) {

--- a/internal/goliac_test.go
+++ b/internal/goliac_test.go
@@ -715,6 +715,9 @@ func (e *GoliacRemoteExecutorMock) EnvironmentSecretsPerRepository(ctx context.C
 func (e *GoliacRemoteExecutorMock) RepositoriesSecretsPerRepository(ctx context.Context, repositoryName string) (map[string]*engine.GithubVariable, error) {
 	return nil, nil
 }
+func (e *GoliacRemoteExecutorMock) OrgCustomProperties(ctx context.Context) map[string]*config.GithubCustomProperty {
+	return make(map[string]*config.GithubCustomProperty)
+}
 func (e *GoliacRemoteExecutorMock) AddRepositoryEnvironment(ctx context.Context, logsCollector *observability.LogCollection, dryrun bool, repositoryName string, environmentName string) {
 	fmt.Println("*** AddRepositoryEnvironment", repositoryName, environmentName)
 	e.nbChanges++

--- a/internal/goliac_test.go
+++ b/internal/goliac_test.go
@@ -718,6 +718,14 @@ func (e *GoliacRemoteExecutorMock) RepositoriesSecretsPerRepository(ctx context.
 func (e *GoliacRemoteExecutorMock) OrgCustomProperties(ctx context.Context) map[string]*config.GithubCustomProperty {
 	return make(map[string]*config.GithubCustomProperty)
 }
+func (e *GoliacRemoteExecutorMock) CreateOrUpdateOrgCustomProperty(ctx context.Context, logsCollector *observability.LogCollection, dryrun bool, property *config.GithubCustomProperty) {
+	fmt.Println("*** CreateOrUpdateOrgCustomProperty", property.PropertyName)
+	e.nbChanges++
+}
+func (e *GoliacRemoteExecutorMock) DeleteOrgCustomProperty(ctx context.Context, logsCollector *observability.LogCollection, dryrun bool, propertyName string) {
+	fmt.Println("*** DeleteOrgCustomProperty", propertyName)
+	e.nbChanges++
+}
 func (e *GoliacRemoteExecutorMock) AddRepositoryEnvironment(ctx context.Context, logsCollector *observability.LogCollection, dryrun bool, repositoryName string, environmentName string) {
 	fmt.Println("*** AddRepositoryEnvironment", repositoryName, environmentName)
 	e.nbChanges++

--- a/internal/scaffold.go
+++ b/internal/scaffold.go
@@ -513,6 +513,17 @@ func (s *Scaffold) generateTeams(ctx context.Context, fs billy.Filesystem, teams
 						break
 					}
 				}
+
+				// scaffold custom properties (inside the if block where rRepo is in scope)
+				if rRepo, ok := rRepos[r]; ok {
+					if len(rRepo.CustomProperties) > 0 {
+						lRepo.Spec.CustomProperties = make(map[string]interface{})
+						for propName, propValue := range rRepo.CustomProperties {
+							lRepo.Spec.CustomProperties[propName] = propValue
+						}
+					}
+				}
+
 				if lRepo.Archived {
 					if err := writeYamlFile(path.Join(archivepath, r+".yaml"), &lRepo, fs); err != nil {
 						logCollector.AddError(fmt.Errorf("not able to write archived repo file %s/%s.yaml: %v", archivepath, r, err))
@@ -658,7 +669,7 @@ spec:
       - appname: %s
         mode: always
     conditions:
-      include: 
+      include:
       - "~DEFAULT_BRANCH"
     rules:
       - ruletype: pull_request
@@ -745,7 +756,7 @@ kind: Repository
 name: awesome-repository
 ` + "```" + `
 
-This will create a ` + "`" + `awesome-repository` + "`" + ` repository under your organization, that will be 
+This will create a ` + "`" + `awesome-repository` + "`" + ` repository under your organization, that will be
 - private by default
 - writable by all owners/members of this team (in our example ` + "`" + `foobar` + "`" + `)
 

--- a/internal/scaffold_test.go
+++ b/internal/scaffold_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/go-git/go-billy/v5/memfs"
+	"github.com/goliac-project/goliac/internal/config"
 	"github.com/goliac-project/goliac/internal/engine"
 	"github.com/goliac-project/goliac/internal/entity"
 	"github.com/goliac-project/goliac/internal/observability"
@@ -69,6 +70,10 @@ func (s *ScaffoldGoliacRemoteMock) EnvironmentSecretsPerRepository(ctx context.C
 
 func (s *ScaffoldGoliacRemoteMock) RepositoriesSecretsPerRepository(ctx context.Context, repositoryName string) (map[string]*engine.GithubVariable, error) {
 	return nil, nil
+}
+
+func (s *ScaffoldGoliacRemoteMock) OrgCustomProperties(ctx context.Context) map[string]*config.GithubCustomProperty {
+	return make(map[string]*config.GithubCustomProperty)
 }
 
 func NewScaffoldGoliacRemoteMock() engine.GoliacRemote {

--- a/internal/utils/deep_equal_unorder.go
+++ b/internal/utils/deep_equal_unorder.go
@@ -2,6 +2,9 @@ package utils
 
 import "reflect"
 
+/*
+ * DeepEqualUnordered compares two interfaces by their values, ignoring the order of the keys in the map
+ */
 func DeepEqualUnordered(a, b interface{}) bool {
 	return deepEqual(reflect.ValueOf(a), reflect.ValueOf(b))
 }


### PR DESCRIPTION
## Summary

This PR adds support for syncing GitHub repository custom properties through Goliac. Custom properties can now be defined in repository YAML manifests and will be automatically synchronized with GitHub repositories.

- [x] `scaffold`, `plan` and `apply` commands tested.

## What Changed

### Features
- **Custom Properties Support**: Repositories can now define `spec.custom_properties` in their YAML manifests
- **Selective Reconciliation**: Goliac only reconciles custom properties specified in the manifest and ignores any other custom properties on the repository
- **Type Handling**: Automatically handles string values, arrays of strings, and null values. Integer values (like `Tier: 2`) are normalized to strings (`"2"`) during YAML parsing
- **Detailed Logging**: Logs changes with old and new values for each modified property
- **Error Reporting**: Provides clear error messages for API validation failures (e.g., 422 errors when property values don't match organization constraints)

### Implementation Details

1. **YAML Parsing** (`internal/entity/repository.go`):
   - Added `CustomProperties` field to `Repository.Spec`
   - Normalizes integer values to strings during unmarshaling

2. **Remote Loading** (`internal/engine/remote.go`):
   - Added `CustomProperties` field to `GithubRepository`
   - Implemented concurrent loading of custom properties from GitHub API
   - Added `UpdateRepositoryCustomProperties` method to update properties via GitHub REST API

3. **Reconciliation** (`internal/engine/goliac_reconciliator.go`):
   - Added custom properties comparison logic
   - Only reconciles properties defined in local spec
   - Logs detailed change information (old/new values)

4. **Scaffolding** (`internal/scaffold.go`):
   - Includes custom properties when scaffolding repository YAML files

5. **Documentation**:
   - Updated `docs/resource_repository.md` with custom properties examples
   - Updated quick start and installation docs

### API Integration

Uses the GitHub REST API endpoint:
- `GET /repos/{owner}/{repo}/properties/values` - to fetch current custom properties
- `PATCH /repos/{owner}/{repo}/properties/values` - to update custom properties

Reference: https://docs.github.com/en/rest/repos/custom-properties?apiVersion=2022-11-28

## Example Usage
aml
apiVersion: v1
kind: Repository
name: my-repository
spec:
  custom_properties:
    Tier: '2'           # String value (integers are normalized to strings)
    Owner: Lions        # String value
    ProductLine: AlayaCare Cloud
    Tags:               # Array of strings
      - production
      - critical
     
## Testing

- All existing tests pass
- Added test mocks for `UpdateRepositoryCustomProperties` method
- Tested with various property value types (string, int, arrays)

## Breaking Changes

None - this is a new feature that doesn't affect existing functionality.

## Related Issues

Fixes the need to manually manage repository custom properties through the GitHub UI or separate tooling.